### PR TITLE
Add SQLAlchemy database engine initialization

### DIFF
--- a/business_intel_scraper/backend/db/__init__.py
+++ b/business_intel_scraper/backend/db/__init__.py
@@ -1,0 +1,24 @@
+"""Database engine setup for the backend."""
+
+from __future__ import annotations
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from .models import Base
+
+
+DATABASE_URL = "sqlite:///./data.db"
+
+# Create the SQLAlchemy engine. ``future=True`` enables 2.0 style usage.
+engine = create_engine(DATABASE_URL, future=True, echo=False)
+
+# Factory for database sessions used throughout the application.
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+
+def init_db() -> None:
+    """Create all database tables if they do not exist."""
+
+    Base.metadata.create_all(bind=engine)
+


### PR DESCRIPTION
## Summary
- initialize SQLAlchemy engine and session factory
- expose `init_db()` helper to create tables

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878457ec6ec8333b95856dbe0fa04f9