### PR TITLE
Add Company CRUD endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.pyc
 .mypy_cache/
+app.db

--- a/business_intel_scraper/backend/api/main.py
+++ b/business_intel_scraper/backend/api/main.py
@@ -1,6 +1,48 @@
 """Main FastAPI application entry point."""
 
-from fastapi import FastAPI
+from __future__ import annotations
+
+from fastapi import Depends, FastAPI, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session, sessionmaker
+
+from ..db.models import Base, Company
+
+# --- Database setup -----------------------------------------------------
+engine = create_engine(
+    "sqlite:///./app.db", connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base.metadata.create_all(bind=engine)
+
+
+def get_db() -> Session:
+    """Provide a SQLAlchemy session dependency."""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+# --- Pydantic schemas ---------------------------------------------------
+
+class CompanyCreate(BaseModel):
+    """Schema for creating companies."""
+
+    name: str
+
+
+class CompanyRead(BaseModel):
+    """Schema for reading companies."""
+
+    id: int
+    name: str
+
+    class Config:
+        orm_mode = True
+
 
 app = FastAPI(title="Business Intelligence Scraper")
 
@@ -15,3 +57,33 @@ async def root() -> dict[str, str]:
         A simple message confirming the service is running.
     """
     return {"message": "API is running"}
+
+
+@app.post("/companies", response_model=CompanyRead, status_code=status.HTTP_201_CREATED)
+def create_company(company: CompanyCreate, db: Session = Depends(get_db)) -> Company:
+    """Create a new ``Company`` record."""
+
+    db_company = Company(name=company.name)
+    db.add(db_company)
+    db.commit()
+    db.refresh(db_company)
+    return db_company
+
+
+@app.get("/companies/{company_id}", response_model=CompanyRead)
+def read_company(company_id: int, db: Session = Depends(get_db)) -> Company:
+    """Retrieve a ``Company`` by ID."""
+
+    stmt = select(Company).where(Company.id == company_id)
+    result = db.execute(stmt).scalar_one_or_none()
+    if result is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Company not found")
+    return result
+
+
+@app.get("/companies", response_model=list[CompanyRead])
+def list_companies(db: Session = Depends(get_db)) -> list[Company]:
+    """List all ``Company`` records."""
+
+    stmt = select(Company)
+    return list(db.execute(stmt).scalars())

--- a/business_intel_scraper/backend/tests/test_api.py
+++ b/business_intel_scraper/backend/tests/test_api.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from business_intel_scraper.backend.api.main import app
+
+client = TestClient(app)
+
+
+def test_create_and_read_company() -> None:
+    resp = client.post("/companies", json={"name": "Acme"})
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["name"] == "Acme"
+    cid = data["id"]
+
+    get_resp = client.get(f"/companies/{cid}")
+    assert get_resp.status_code == 200
+    assert get_resp.json() == data
+
+    list_resp = client.get("/companies")
+    assert list_resp.status_code == 200
+    assert any(item["id"] == cid for item in list_resp.json())


### PR DESCRIPTION
## Summary
- implement simple SQLite engine
- add create/list/get company endpoints in FastAPI app
- ignore `app.db` file
- test API endpoints with FastAPI's TestClient

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878458d31308333bde867daccab0002