### PR TITLE
Add OSINT tool integrations

### DIFF
--- a/business_intel_scraper/backend/osint/integrations.py
+++ b/business_intel_scraper/backend/osint/integrations.py
@@ -1,10 +1,30 @@
-"""OSINT tool integration stubs."""
+"""Wrappers for common OSINT tools.
+
+This module provides thin wrappers around command line utilities used for
+open-source intelligence (OSINT) gathering.  The functions are intentionally
+light-weight and only execute the tools if they are installed on the system.
+The output of each command is captured and returned as a simple dictionary so
+that higher level code does not have to deal with subprocess management.
+
+The wrappers degrade gracefully when the underlying command line tools are not
+available, returning an error string in the result instead of raising
+exceptions.  This makes it easier to run unit tests or to operate in minimal
+environments where SpiderFoot or TheHarvester are not installed.
+"""
 
 from __future__ import annotations
 
+import shutil
+import subprocess
+
 
 def run_spiderfoot(domain: str) -> dict[str, str]:
-    """Placeholder for SpiderFoot integration.
+    """Run SpiderFoot against a domain.
+
+    The function expects the ``spiderfoot`` (or ``sf.py``) executable to be
+    available on the ``PATH``.  If the executable cannot be found the returned
+    dictionary contains an ``error`` key describing the problem instead of
+    raising an exception.
 
     Parameters
     ----------
@@ -14,6 +34,48 @@ def run_spiderfoot(domain: str) -> dict[str, str]:
     Returns
     -------
     dict[str, str]
-        Results of the OSINT query.
+        ``domain`` plus either ``output`` from the command or an ``error``
+        message.
     """
-    return {"domain": domain}
+
+    executable = (
+        shutil.which("spiderfoot")
+        or shutil.which("sf.py")
+        or shutil.which("sf")
+    )
+    if executable is None:
+        return {"domain": domain, "error": "SpiderFoot executable not found"}
+
+    cmd = [executable, "-q", domain, "-F", "json"]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    output = proc.stdout.strip() or proc.stderr.strip()
+    return {"domain": domain, "output": output}
+
+
+def run_theharvester(domain: str) -> dict[str, str]:
+    """Run TheHarvester against a domain.
+
+    Similar to :func:`run_spiderfoot`, this wrapper relies on the presence of
+    the ``theharvester`` executable.  The function does not attempt to parse the
+    output; instead the raw command output is returned.
+
+    Parameters
+    ----------
+    domain : str
+        Domain to investigate.
+
+    Returns
+    -------
+    dict[str, str]
+        ``domain`` plus either ``output`` from the command or an ``error``
+        message.
+    """
+
+    executable = shutil.which("theharvester")
+    if executable is None:
+        return {"domain": domain, "error": "theHarvester executable not found"}
+
+    cmd = [executable, "-d", domain, "-b", "all"]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    output = proc.stdout.strip() or proc.stderr.strip()
+    return {"domain": domain, "output": output}


### PR DESCRIPTION
## Summary
- flesh out OSINT wrappers
- gracefully handle missing SpiderFoot and TheHarvester tools

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687845bc23a88333a5e775d7e797c298