### PR TITLE
Add browser crawler for dynamic pages

### DIFF
--- a/business_intel_scraper/README.md
+++ b/business_intel_scraper/README.md
@@ -81,6 +81,8 @@ Project Structure
 │
 ├── backend/
 │   ├── crawlers/
+│   │   ├── spider.py  - Scrapy spider
+│   │   └── browser.py - Playwright/Selenium crawler
 │   ├── osint/
 │   ├── nlp/
 │   ├── geo/
@@ -112,6 +114,7 @@ Getting Started
     Run sample pipeline:
 
         Launch crawler via API or CLI
+        Use ``BrowserCrawler`` for dynamic pages requiring JavaScript rendering
 
         Monitor dashboards for block/ban rates
 

--- a/business_intel_scraper/backend/crawlers/__init__.py
+++ b/business_intel_scraper/backend/crawlers/__init__.py
@@ -1,0 +1,14 @@
+"""Crawler module providing Scrapy spiders and browser-based crawlers."""
+
+try:
+    from .spider import ExampleSpider
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    ExampleSpider = None  # type: ignore
+
+from .browser import BrowserCrawler
+
+__all__ = ["BrowserCrawler"]
+if ExampleSpider is not None:
+    __all__.insert(0, "ExampleSpider")
+
+

--- a/business_intel_scraper/backend/crawlers/browser.py
+++ b/business_intel_scraper/backend/crawlers/browser.py
@@ -1,0 +1,48 @@
+"""Browser-based crawler for dynamic pages."""
+
+from __future__ import annotations
+
+import logging
+
+try:
+    from playwright.sync_api import sync_playwright
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    sync_playwright = None  # type: ignore
+
+try:
+    from selenium import webdriver
+    from selenium.webdriver.chrome.options import Options as ChromeOptions
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    webdriver = None  # type: ignore
+    ChromeOptions = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+
+class BrowserCrawler:
+    """Simple crawler that renders JavaScript using Playwright or Selenium."""
+
+    def __init__(self, headless: bool = True) -> None:
+        self.headless = headless
+
+    def fetch(self, url: str) -> str:
+        """Fetch page content after scripts execute."""
+        if sync_playwright is not None:
+            with sync_playwright() as pw:
+                browser = pw.chromium.launch(headless=self.headless)
+                page = browser.new_page()
+                page.goto(url)
+                content = page.content()
+                browser.close()
+                return content
+        if webdriver is not None and ChromeOptions is not None:
+            options = ChromeOptions()
+            if self.headless:
+                options.add_argument("--headless")
+            driver = webdriver.Chrome(options=options)
+            driver.get(url)
+            content = driver.page_source
+            driver.quit()
+            return content
+        raise RuntimeError("Playwright or Selenium is required to fetch dynamic pages")
+

--- a/business_intel_scraper/backend/tests/test_browser_crawler.py
+++ b/business_intel_scraper/backend/tests/test_browser_crawler.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import pytest
+
+from business_intel_scraper.backend.crawlers.browser import BrowserCrawler
+
+
+def test_browser_crawler_requires_dependency(monkeypatch) -> None:
+    """Ensure RuntimeError raised when no browser backends available."""
+    monkeypatch.setattr(
+        "business_intel_scraper.backend.crawlers.browser.sync_playwright", None
+    )
+    monkeypatch.setattr(
+        "business_intel_scraper.backend.crawlers.browser.webdriver", None
+    )
+    monkeypatch.setattr(
+        "business_intel_scraper.backend.crawlers.browser.ChromeOptions", None
+    )
+    crawler = BrowserCrawler()
+    with pytest.raises(RuntimeError):
+        crawler.fetch("https://example.com")
+


### PR DESCRIPTION
## Summary
- add `BrowserCrawler` supporting Playwright or Selenium for JS-rendered sites
- gracefully import Scrapy spider in crawlers package
- document BrowserCrawler usage in project README
- add unit test for BrowserCrawler fallback behavior

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687845ab5a108333b2c4d4d6900d85ca