### PR TITLE
Add geocoding utility

### DIFF
--- a/business_intel_scraper/backend/geo/processing.py
+++ b/business_intel_scraper/backend/geo/processing.py
@@ -4,10 +4,18 @@ from __future__ import annotations
 
 from typing import Iterable, Tuple
 
+import json
+import time
+import urllib.parse
+import urllib.request
+
+
+NOMINATIM_URL = "https://nominatim.openstreetmap.org/search"
+
 
 def geocode_addresses(
     addresses: Iterable[str],
-) -> list[Tuple[str, float, float]]:
+) -> list[Tuple[str, float | None, float | None]]:
     """Geocode a list of addresses.
 
     Parameters
@@ -20,4 +28,27 @@ def geocode_addresses(
     list[Tuple[str, float, float]]
         Tuples containing address and latitude/longitude.
     """
-    return []
+    results: list[Tuple[str, float | None, float | None]] = []
+
+    for address in addresses:
+        query = urllib.parse.urlencode({"q": address, "format": "json"})
+        req = urllib.request.Request(
+            f"{NOMINATIM_URL}?{query}",
+            headers={"User-Agent": "business-intel-scraper/1.0"},
+        )
+
+        try:
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                data = json.load(resp)
+            if data:
+                lat = float(data[0]["lat"])
+                lon = float(data[0]["lon"])
+                results.append((address, lat, lon))
+            else:
+                results.append((address, None, None))
+        except Exception:  # pragma: no cover - network issues
+            results.append((address, None, None))
+
+        time.sleep(1)
+
+    return results

--- a/business_intel_scraper/backend/tests/test_geo_processing.py
+++ b/business_intel_scraper/backend/tests/test_geo_processing.py
@@ -1,0 +1,38 @@
+import io
+import json
+import urllib.request
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+from business_intel_scraper.backend.geo.processing import geocode_addresses
+
+
+def fake_urlopen_factory(response_json: str):
+    class FakeResponse(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            self.close()
+
+    def fake_urlopen(_req: urllib.request.Request, timeout: int = 10):
+        return FakeResponse(response_json.encode())
+
+    return fake_urlopen
+
+
+def test_geocode_addresses(monkeypatch: pytest.MonkeyPatch) -> None:
+    mock_response = json.dumps([
+        {"lat": "51.5074", "lon": "-0.1278"}
+    ])
+    monkeypatch.setattr(
+        urllib.request, "urlopen", fake_urlopen_factory(mock_response)
+    )
+    monkeypatch.setattr("time.sleep", lambda _x: None)
+
+    results = geocode_addresses(["London"])
+    assert results == [("London", 51.5074, -0.1278)]


### PR DESCRIPTION
## Summary
- implement geocoding using Nominatim in `geocode_addresses`
- unit test for `geocode_addresses`

## Testing
- `pytest -q`
- `ruff check business_intel_scraper/backend/geo/processing.py`
- `ruff check business_intel_scraper/backend/tests/test_geo_processing.py`


------
https://chatgpt.com/codex/tasks/task_e_687845d43df883338205c5d13d4010e8