### PR TITLE
Add rate limiting middleware

### DIFF
--- a/business_intel_scraper/backend/api/main.py
+++ b/business_intel_scraper/backend/api/main.py
@@ -2,7 +2,10 @@
 
 from fastapi import FastAPI
 
+from .rate_limit import RateLimitMiddleware
+
 app = FastAPI(title="Business Intelligence Scraper")
+app.add_middleware(RateLimitMiddleware)
 
 
 @app.get("/")

--- a/business_intel_scraper/backend/api/rate_limit.py
+++ b/business_intel_scraper/backend/api/rate_limit.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+"""Simple in-memory rate limiting middleware."""
+
+from collections import defaultdict, deque
+from time import time
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.status import HTTP_429_TOO_MANY_REQUESTS
+
+
+class RateLimitMiddleware(BaseHTTPMiddleware):
+    """Limit number of requests per client within a time window."""
+
+    def __init__(self, app, limit: int = 60, window: int = 60) -> None:
+        super().__init__(app)
+        self.limit = limit
+        self.window = window
+        self._requests: dict[str, deque[float]] = defaultdict(deque)
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        client_ip = request.client.host
+        now = time()
+        history = self._requests[client_ip]
+        while history and now - history[0] > self.window:
+            history.popleft()
+        if len(history) >= self.limit:
+            return Response(
+                content="Too Many Requests",
+                status_code=HTTP_429_TOO_MANY_REQUESTS,
+            )
+        history.append(now)
+        return await call_next(request)

--- a/business_intel_scraper/backend/tests/test_rate_limit.py
+++ b/business_intel_scraper/backend/tests/test_rate_limit.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from business_intel_scraper.backend.api.rate_limit import RateLimitMiddleware
+
+
+def create_test_app(limit: int = 2) -> TestClient:
+    app = FastAPI()
+    app.add_middleware(RateLimitMiddleware, limit=limit, window=60)
+
+    @app.get("/")
+    async def root() -> dict[str, str]:
+        return {"message": "ok"}
+
+    return TestClient(app)
+
+
+def test_rate_limiter_blocks_after_limit() -> None:
+    client = create_test_app(limit=1)
+    assert client.get("/").status_code == 200
+    second = client.get("/")
+    assert second.status_code == 429


### PR DESCRIPTION
## Summary
- implement simple in-memory rate limiter middleware
- enable middleware in `main.py`
- test that the rate limiter blocks after limit is exceeded

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687845f3b70c83339df455cfe4f604f3