### PR TITLE
Add SQLAlchemy repository layer

### DIFF
--- a/business_intel_scraper/backend/db/repository.py
+++ b/business_intel_scraper/backend/db/repository.py
@@ -1,0 +1,50 @@
+"""Repository classes for database access."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from .models import Base, Company
+
+# Create a simple SQLite engine for demonstration purposes
+ENGINE = create_engine("sqlite:///business_intel.db", echo=False)
+SessionLocal = sessionmaker(bind=ENGINE)
+
+
+def init_db() -> None:
+    """Initialize database tables."""
+    Base.metadata.create_all(bind=ENGINE)
+
+
+class CompanyRepository:
+    """Repository for :class:`~.models.Company` objects."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def add(self, name: str) -> Company:
+        """Persist a new company record."""
+        company = Company(name=name)
+        self._session.add(company)
+        self._session.commit()
+        self._session.refresh(company)
+        return company
+
+    def get(self, company_id: int) -> Optional[Company]:
+        """Retrieve a company by primary key."""
+        return self._session.get(Company, company_id)
+
+    def list(self) -> list[Company]:
+        """Return all companies."""
+        stmt = self._session.query(Company)
+        return list(stmt.all())
+
+    def delete(self, company_id: int) -> None:
+        """Delete a company record."""
+        company = self.get(company_id)
+        if company is not None:
+            self._session.delete(company)
+            self._session.commit()

--- a/business_intel_scraper/backend/tests/test_repository.py
+++ b/business_intel_scraper/backend/tests/test_repository.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+# Ensure package root is on the path when running tests directly from the
+# repository checkout.
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from business_intel_scraper.backend.db.repository import (
+    CompanyRepository,
+    SessionLocal,
+    init_db,
+)
+
+
+def test_company_repository_add_and_get(tmp_path):
+    """CompanyRepository should persist and retrieve records."""
+    # initialize database
+    init_db()
+    session = SessionLocal()
+    repo = CompanyRepository(session)
+
+    company = repo.add("ACME Corp")
+    fetched = repo.get(company.id)
+
+    assert fetched is not None
+    assert fetched.name == "ACME Corp"
+    session.close()


### PR DESCRIPTION
## Summary
- add a repository module for CRUD operations on `Company`
- provide initialization utility to create tables
- add tests to verify persistence logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878458a8bdc83338c30cfe7caa52a68