### PR TITLE
Add environment config loader

### DIFF
--- a/business_intel_scraper/README.md
+++ b/business_intel_scraper/README.md
@@ -104,6 +104,8 @@ Project Structure
 Getting Started
 
     Clone repository and configure .env
+    Project settings are accessed via ``business_intel_scraper.config`` which
+    reads variables from the ``.env`` file and the environment.
 
     Bring up infra stack (docker-compose up or kubernetes deploy)
 

--- a/business_intel_scraper/backend/tests/test_config.py
+++ b/business_intel_scraper/backend/tests/test_config.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import importlib
+import os
+from pathlib import Path
+
+import pytest
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+config = pytest.importorskip("business_intel_scraper.config")
+
+
+def test_load_env_file(tmp_path: Path, monkeypatch) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text("API_KEY=loaded\n")
+    monkeypatch.delenv("API_KEY", raising=False)
+    config._load_env_file(env_file)
+    assert os.getenv("API_KEY") == "loaded"
+
+
+def test_settings_reads_env(monkeypatch) -> None:
+    monkeypatch.setenv("API_KEY", "from_env")
+    module = importlib.reload(config)
+    assert module.settings.api_key == "from_env"

--- a/business_intel_scraper/config.py
+++ b/business_intel_scraper/config.py
@@ -1,0 +1,34 @@
+"""Application configuration loader."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+
+def _load_env_file(path: Path) -> None:
+    """Load environment variables from a ``.env`` file if present."""
+    if not path.exists():
+        return
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith('#') or '=' not in line:
+            continue
+        key, value = line.split('=', 1)
+        os.environ.setdefault(key, value)
+
+
+# Attempt to load ``.env`` next to this file
+_load_env_file(Path(__file__).resolve().parent / ".env")
+
+
+@dataclass
+class Settings:
+    """Container for application settings."""
+
+    api_key: str = os.getenv("API_KEY", "")
+
+
+# Singleton settings instance used across the project
+settings = Settings()


### PR DESCRIPTION
## Summary
- implement `business_intel_scraper.config` for central settings
- document configuration in README
- test config loader behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68784579166c8333ab52a7c6b0afa488