### PR TITLE
Fix setup_logging helper

### DIFF
--- a/business_intel_scraper/backend/utils/helpers.py
+++ b/business_intel_scraper/backend/utils/helpers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
 LOG_DIR = Path(__file__).resolve().parents[1] / "logs"
@@ -11,8 +12,6 @@ LOG_FILE = LOG_DIR / "app.log"
 logger = logging.getLogger(__name__)
 
 
-def setup_logging(level: int = logging.INFO) -> None:
-    """Configure basic logging to stdout and a file.
 def setup_logging(
     level: int = logging.INFO,
     log_file: str | Path = "logs/backend.log",
@@ -21,6 +20,10 @@ def setup_logging(
 ) -> None:
     """Configure application logging.
 
+    A stream handler writes logs to ``stdout`` while a rotating file
+    handler persists them to ``log_file``. Existing handlers are left
+    intact so this function can be called multiple times safely.
+
     Parameters
     ----------
     level : int, optional
@@ -28,17 +31,12 @@ def setup_logging(
     log_file : str | Path, optional
         Path to the log file, by default ``"logs/backend.log"``.
     max_bytes : int, optional
-        Maximum bytes before rotating the log file, by default ``10 * 1024 * 1024``.
+        Maximum bytes before rotating the log file, by default
+        ``10 * 1024 * 1024``.
     backup_count : int, optional
         Number of rotated log files to keep, by default ``5``.
     """
     LOG_DIR.mkdir(parents=True, exist_ok=True)
-    handlers = [logging.StreamHandler(), logging.FileHandler(LOG_FILE)]
-    logging.basicConfig(
-        level=level,
-        format="%(asctime)s - %(levelname)s - %(message)s",
-        handlers=handlers,
-    )
     log_path = Path(log_file)
     log_path.parent.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
## Summary
- clean up duplicate `setup_logging` signature
- document the helper and import `RotatingFileHandler`

## Testing
- `pytest business_intel_scraper/backend/tests/test_proxy_manager.py::test_random_selection -q`
- `pytest -q` *(fails: RateLimitMiddleware not defined, bad imports, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68784c35605483339b2821343f8b78b8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved logging setup to use rotating log files and ensure log directories exist, providing more robust and manageable logging.
  * Updated log formatting and clarified documentation for the logging configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->