### PR TITLE
Fix missing RateLimitMiddleware import

### DIFF
--- a/business_intel_scraper/backend/api/main.py
+++ b/business_intel_scraper/backend/api/main.py
@@ -7,6 +7,7 @@ from .notifications import ConnectionManager
 from ..workers.tasks import get_task_status, launch_scraping_task
 
 from business_intel_scraper.settings import settings
+from .rate_limit import RateLimitMiddleware
 
 app = FastAPI(title="Business Intelligence Scraper")
 app.add_middleware(RateLimitMiddleware)


### PR DESCRIPTION
## Summary
- import `RateLimitMiddleware` in FastAPI app so the middleware can be registered

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: EventSourceResponse not defined and other missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68784c344ccc8333b86b6b55650bed4c