### PR TITLE
Add frontend README

### DIFF
--- a/business_intel_scraper/frontend/README.md
+++ b/business_intel_scraper/frontend/README.md
@@ -1,0 +1,19 @@
+# Frontend Development Setup
+
+This directory holds a minimal frontend application. The only dependency is listed in `package.json`, but running `npm install` ensures all Node modules are present.
+
+## Install Node dependencies
+
+```bash
+npm install
+```
+
+## Start the development server
+
+Use the following command to serve the `public` folder locally.
+
+```bash
+npm start
+```
+
+The server runs on [http://localhost:8000](http://localhost:8000) by default.


### PR DESCRIPTION
## Summary
- document frontend setup in `business_intel_scraper/frontend/README.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68784c41c2948333bd7e0a8bbba13706