### PR TITLE
Add CI workflow for pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: ["main", "master"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest fastapi starlette httpx sqlalchemy scrapy sse-starlette uvicorn pydantic selenium playwright
+      - name: Run tests
+        run: pytest -q


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to install dependencies and run pytest

## Testing
- `pytest -q` *(fails: RateLimitMiddleware not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68784c405c64833392f024cb52f7681d