### PR TITLE
Add environment example and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Example environment configuration
+API_KEY=your_api_key_here
+DATABASE_URL=sqlite:///data.db
+PROXY_URL=
+CELERY_BROKER_URL=redis://localhost:6379/0
+CELERY_RESULT_BACKEND=redis://localhost:6379/0

--- a/README.md
+++ b/README.md
@@ -10,6 +10,19 @@ The backend is built with FastAPI and exposes a simple health check at `/`.
 
 Real-time notifications are available via a WebSocket endpoint at `/ws/notifications`. Messages sent by any connected client are broadcast to all clients.
 
+## Configuration
+
+Copy `.env.example` to `.env` and update the values as needed. The application
+recognizes the following settings:
+
+```
+API_KEY=your_api_key_here
+DATABASE_URL=sqlite:///data.db
+PROXY_URL=
+CELERY_BROKER_URL=redis://localhost:6379/0
+CELERY_RESULT_BACKEND=redis://localhost:6379/0
+```
+
 # scraper
 
 ## Log Streaming


### PR DESCRIPTION
## Summary
- add `.env.example` to project root
- document environment variables in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68784c3b8e1483339cfec6adab90f39e