### PR TITLE
Add backend config module

### DIFF
--- a/business_intel_scraper/backend/config.py
+++ b/business_intel_scraper/backend/config.py
@@ -1,0 +1,24 @@
+"""Backend application settings."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Configuration loaded from environment variables."""
+
+    api_key: str = ""
+    database_url: str = "sqlite:///./development.db"
+    proxy_url: str = ""
+    celery_broker_url: str = "redis://localhost:6379/0"
+    celery_result_backend: str = "redis://localhost:6379/0"
+
+    class Config:
+        env_file = Path(__file__).resolve().parent / ".env"
+        case_sensitive = False
+
+
+settings = Settings()


### PR DESCRIPTION
## Summary
- add `business_intel_scraper/backend/config.py` with `pydantic` settings
- settings expose API key, database URL and other optional values

## Testing
- `pytest business_intel_scraper/backend/tests/test_config.py -q`
- `pytest -q` *(fails: test_auth_helpers.py::test_verify_token_accepts_non_empty, test_example.py::test_save_companies_deduplication, test_geo.py::test_geocode_addresses_persists_locations, test_geo_processing.py::test_geocode_addresses, test_repository.py::test_company_repository_add_and_get)*

------
https://chatgpt.com/codex/tasks/task_e_6878ec35034c8333a91e4e10a1bf04ba

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved backend configuration management to support environment-based settings, allowing easier customization of API keys, database connections, proxies, and background task processing via environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->