### PR TITLE
Use config settings for DB engine

### DIFF
--- a/business_intel_scraper/backend/db/__init__.py
+++ b/business_intel_scraper/backend/db/__init__.py
@@ -2,15 +2,12 @@
 
 from __future__ import annotations
 
-import os
-
+from business_intel_scraper.config import settings
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./development.db")
-
-engine = create_engine(DATABASE_URL, echo=True)
+engine = create_engine(settings.database_url, echo=True)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 
@@ -22,5 +19,3 @@ def get_db():
         yield db
     finally:
         db.close()
-
-

--- a/business_intel_scraper/config.py
+++ b/business_intel_scraper/config.py
@@ -13,9 +13,9 @@ def _load_env_file(path: Path) -> None:
         return
     for line in path.read_text().splitlines():
         line = line.strip()
-        if not line or line.startswith('#') or '=' not in line:
+        if not line or line.startswith("#") or "=" not in line:
             continue
-        key, value = line.split('=', 1)
+        key, value = line.split("=", 1)
         os.environ.setdefault(key, value)
 
 
@@ -28,6 +28,7 @@ class Settings:
     """Container for application settings."""
 
     api_key: str = os.getenv("API_KEY", "")
+    database_url: str = os.getenv("DATABASE_URL", "sqlite:///data.db")
     use_https: bool = os.getenv("USE_HTTPS", "false").lower() == "true"
     rate_limit: int = int(os.getenv("RATE_LIMIT", "60"))
     rate_limit_window: int = int(os.getenv("RATE_LIMIT_WINDOW", "60"))


### PR DESCRIPTION
## Summary
- provide a database_url in `config.py`
- initialize the SQLAlchemy engine using the value from `config.settings`
- expose `SessionLocal` for DB sessions

## Testing
- `ruff check business_intel_scraper/backend/db/__init__.py business_intel_scraper/config.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_6878ec35e1fc83339ad1b2470ecd6fa8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration handling to centralize database URL settings.
  * Improved consistency in environment variable parsing.
  * Added a new configuration option for specifying the database URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->