### PR TITLE
Initialize Celery from settings

### DIFF
--- a/business_intel_scraper/backend/workers/__init__.py
+++ b/business_intel_scraper/backend/workers/__init__.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-import os
 from typing import Callable, TypeVar, Any
+
+from business_intel_scraper.settings import settings
 
 try:
     from celery import Celery
@@ -20,8 +21,8 @@ except ModuleNotFoundError:  # pragma: no cover - optional dependency
             return func
 
 
-broker_url = os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0")
-result_backend = os.getenv("CELERY_RESULT_BACKEND", broker_url)
+broker_url = settings.celery.broker_url
+result_backend = settings.celery.result_backend
 
 # Instantiate the Celery application with configured broker and backend
 celery_app = Celery("tasks", broker=broker_url, backend=result_backend)

--- a/business_intel_scraper/settings.py
+++ b/business_intel_scraper/settings.py
@@ -37,6 +37,14 @@ class RateLimitSettings:
 
 
 @dataclass
+class CelerySettings:
+    """Celery task queue configuration."""
+
+    broker_url: str = os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0")
+    result_backend: str = os.getenv("CELERY_RESULT_BACKEND", broker_url)
+
+
+@dataclass
 class Settings:
     """Container for all application settings."""
 
@@ -44,6 +52,7 @@ class Settings:
     database: DatabaseSettings = field(default_factory=DatabaseSettings)
     proxy: ProxySettings = field(default_factory=ProxySettings)
     rate_limit: RateLimitSettings = field(default_factory=RateLimitSettings)
+    celery: CelerySettings = field(default_factory=CelerySettings)
     require_https: bool = os.getenv("USE_HTTPS", "false").lower() == "true"
 
 


### PR DESCRIPTION
## Summary
- add Celery settings dataclass
- use settings to configure Celery workers

## Testing
- `PYTHONPATH=. pytest -q` *(fails: 5 failed, 27 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6878ec3a05a48333889133ca137d9e6b