### PR TITLE
Fix celery task imports

### DIFF
--- a/business_intel_scraper/backend/workers/tasks.py
+++ b/business_intel_scraper/backend/workers/tasks.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+import time
 from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Dict
 
@@ -24,34 +25,7 @@ from business_intel_scraper.backend.db.utils import (
 )
 from business_intel_scraper.backend.db.models import Company
 
-try:
-    from celery import Celery
-except ModuleNotFoundError:  # pragma: no cover - optional dependency
-
-    from typing import Callable, TypeVar, Any
-
-    F = TypeVar("F", bound=Callable[..., Any])
-
-    class Celery:  # type: ignore
-        """Fallback Celery replacement."""
-
-        def __init__(self, *args: object, **kwargs: object) -> None:
-            pass
-
-        def config_from_object(self, *args: object, **kwargs: object) -> None:
-            return None
-
-        def task(self, func: F) -> F:  # type: ignore[no-untyped-def]
-            return func
-
-celery_app = Celery("business_intel_scraper")
-
-try:  # pragma: no cover - optional dependency
-    celery_app.config_from_object(
-        "business_intel_scraper.backend.workers.celery_config", namespace="CELERY"
-    )
-except ModuleNotFoundError:
-    pass
+from . import celery_app
 
 
 try:


### PR DESCRIPTION
## Summary
- switch Celery tasks to use `celery_app` from `backend/workers/__init__.py`
- add missing `time` import when gevent isn't installed

## Testing
- `pytest business_intel_scraper/backend/tests/test_spider_task.py::test_run_spider_task_html business_intel_scraper/backend/tests/test_example.py::test_example_task -q`

------
https://chatgpt.com/codex/tasks/task_e_6878ec3a6eb883339ba82e530e4a2385