### PR TITLE
Add generic spider task

### DIFF
--- a/business_intel_scraper/backend/workers/tasks.py
+++ b/business_intel_scraper/backend/workers/tasks.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import uuid
 from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Dict
+import time
 
 try:
     from gevent.pool import Pool
@@ -160,15 +161,16 @@ def get_task_status(task_id: str) -> str:
     return "running"
 
 @celery_app.task
-def run_spider_task(spider: str = "example", html: str | None = None) -> list[dict[str, str]]:
+def run_spider_task(spider_name: str = "example", **kwargs: object) -> list[dict[str, str]]:
     """Run a Scrapy spider.
 
     Parameters
     ----------
-    spider : str, optional
+    spider_name : str, optional
         Name of the spider to run. Only ``"example"`` is supported.
-    html : str, optional
-        Optional HTML body to parse instead of fetching from the network.
+    **kwargs : object
+        Additional arguments passed to the spider. Currently only ``html`` is
+        recognised and used when provided.
 
     Returns
     -------
@@ -177,14 +179,16 @@ def run_spider_task(spider: str = "example", html: str | None = None) -> list[di
     """
     from importlib import import_module
 
-    if spider != "example":
-        raise ValueError(f"Unknown spider '{spider}'")
+    if spider_name != "example":
+        raise ValueError(f"Unknown spider '{spider_name}'")
 
     try:
         module = import_module("business_intel_scraper.backend.crawlers.spider")
         spider_cls = getattr(module, "ExampleSpider")
     except Exception:  # pragma: no cover - unexpected import failure
         return []
+
+    html = kwargs.get("html")
 
     if html is not None:
         spider_instance = spider_cls()


### PR DESCRIPTION
## Summary
- enable fallback import for task runner
- update `run_spider_task` to accept a spider name and kwargs

## Testing
- `pytest business_intel_scraper/backend/tests/test_spider_task.py::test_run_spider_task_html -q`
- `pytest -q` *(fails: test_verify_token_accepts_non_empty, test_save_companies_deduplication, test_geocode_addresses_persists_locations, test_geocode_addresses, test_company_repository_add_and_get)*

------
https://chatgpt.com/codex/tasks/task_e_6878ec3b17388333be1b01339fcfaa88