### PR TITLE
Add proxy fetching and rotation support

### DIFF
--- a/business_intel_scraper/backend/browser/playwright_utils.py
+++ b/business_intel_scraper/backend/browser/playwright_utils.py
@@ -1,8 +1,6 @@
-from __future__ import annotations
-
 """Utilities for launching Playwright browsers with proxies."""
 
-from typing import Optional
+from __future__ import annotations
 
 from playwright.async_api import async_playwright, Browser
 
@@ -11,7 +9,14 @@ from ..proxy.manager import ProxyManager
 
 async def launch_browser(proxy_manager: ProxyManager, headless: bool = True) -> Browser:
     """Launch a Chromium browser using a proxy from the manager."""
+
     proxy = proxy_manager.get_proxy()
     playwright = await async_playwright().start()
-    browser = await playwright.chromium.launch(headless=headless, proxy={"server": proxy})
+    try:
+        browser = await playwright.chromium.launch(
+            headless=headless, proxy={"server": proxy}
+        )
+    except Exception:
+        proxy_manager.rotate_proxy()
+        raise
     return browser

--- a/business_intel_scraper/backend/proxy/__init__.py
+++ b/business_intel_scraper/backend/proxy/__init__.py
@@ -1,11 +1,19 @@
 """Proxy utilities package."""
 
 from .manager import ProxyManager
-from .provider import ProxyProvider, DummyProxyProvider, APIProxyProvider
+from .provider import (
+    ProxyProvider,
+    DummyProxyProvider,
+    APIProxyProvider,
+    fetch_fresh_proxy,
+    fetch_fresh_proxies,
+)
 
 __all__ = [
     "ProxyManager",
     "ProxyProvider",
     "DummyProxyProvider",
     "APIProxyProvider",
+    "fetch_fresh_proxy",
+    "fetch_fresh_proxies",
 ]


### PR DESCRIPTION
## Summary
- add helpers to fetch fresh proxies
- integrate proxy rotation into Scrapy middleware
- rotate proxies when browser crawling fails
- expose new utilities via `backend.proxy`

## Testing
- `ruff check business_intel_scraper/backend/proxy/provider.py business_intel_scraper/backend/crawlers/browser.py business_intel_scraper/backend/browser/playwright_utils.py business_intel_scraper/backend/crawlers/middleware.py business_intel_scraper/backend/proxy/__init__.py`
- `pytest -q` *(fails: test_verify_token_accepts_non_empty, test_save_companies_deduplication, test_geocode_addresses_persists_locations, test_geocode_addresses, test_company_repository_add_and_get)*

------
https://chatgpt.com/codex/tasks/task_e_6878ec3e979483339157adcb4b23fb5d