### PR TITLE
Add CAPTCHA stub call in spiders

### DIFF
--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/quotes.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/quotes.py
@@ -1,12 +1,19 @@
 import scrapy
 from typing import Iterable
 
+from ...security import solve_captcha
+
+
 class QuotesSpider(scrapy.Spider):
     name = "quotes"
     allowed_domains = ["quotes.toscrape.com"]
     start_urls = ["https://quotes.toscrape.com/"]
 
     def parse(self, response: scrapy.http.Response) -> Iterable[dict[str, str]]:
+        if "captcha" in response.text.lower():
+            solve_captcha(b"dummy")
+            return
+
         for quote in response.css("div.quote"):
             yield {
                 "text": quote.css("span.text::text").get(),

--- a/business_intel_scraper/backend/crawlers/spider.py
+++ b/business_intel_scraper/backend/crawlers/spider.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import scrapy
 
-from .middleware import ProxyMiddleware
+from ..security import solve_captcha
+
 from ..proxy.provider import DummyProxyProvider
 
 
@@ -39,4 +40,8 @@ class ExampleSpider(scrapy.Spider):
         scrapy.Item | dict[str, str]
             Parsed item from the page.
         """
+        if "captcha" in response.text.lower():
+            solve_captcha(b"dummy")
+            return {}
+
         return {"url": response.url}


### PR DESCRIPTION
## Summary
- update example Scrapy spider to check for CAPTCHA pages and invoke `solve_captcha`
- do the same for the quotes spider

## Testing
- `ruff check business_intel_scraper/backend/crawlers/spider.py business_intel_scraper/backend/crawlers/crawler_project/spiders/quotes.py`
- `black business_intel_scraper/backend/crawlers/crawler_project/spiders/quotes.py business_intel_scraper/backend/crawlers/spider.py`
- `PYTHONPATH=. pytest -q` *(fails: Company mapper errors)*

------
https://chatgpt.com/codex/tasks/task_e_6878ec3ffbd48333ae9f037974326bdd