### PR TITLE
Add documentation for setup and API usage

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,7 @@
+# Project Documentation
+
+This directory contains supplementary documentation for the Business Intelligence Scraper.
+
+* [Setup](setup.md) – install dependencies and run the stack
+* [API Usage](api_usage.md) – example requests for the backend
+* [Developer Guide](developer_guide.md) – coding standards and local development

--- a/docs/api_usage.md
+++ b/docs/api_usage.md
@@ -1,0 +1,59 @@
+# API Usage
+
+The FastAPI backend exposes several routes for launching scraping tasks and
+retrieving results. The examples below assume the API is running locally on
+`http://localhost:8000`.
+
+## Health Check
+
+```bash
+curl http://localhost:8000/
+```
+
+## Start a Scraping Job
+
+```bash
+curl -X POST http://localhost:8000/scrape
+```
+
+The response contains a `task_id` which can be polled for status.
+
+## Check Task Status
+
+```bash
+curl http://localhost:8000/tasks/<task_id>
+```
+
+## View Scraped Data
+
+```bash
+curl http://localhost:8000/data
+```
+
+## Job Information
+
+List all known jobs:
+
+```bash
+curl http://localhost:8000/jobs
+```
+
+Query a single job:
+
+```bash
+curl http://localhost:8000/jobs/<task_id>
+```
+
+## Real-Time Notifications
+
+Open a WebSocket connection to `/ws/notifications` to receive broadcast
+messages from the server. Each connected client will receive any message sent by
+another client.
+
+## Log Streaming
+
+Logs can be streamed with Server-Sent Events:
+
+```bash
+curl http://localhost:8000/logs/stream
+```

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -1,0 +1,31 @@
+# Developer Guide
+
+This project follows a few simple conventions to keep the codebase consistent.
+
+## Code Style
+
+- Format all Python files with **black**.
+- Lint the project with **ruff** and fix issues when possible.
+
+```bash
+pip install black ruff
+black .
+ruff .
+```
+
+Use `ruff --fix .` to automatically apply safe fixes.
+
+## Running Tests
+
+Install the development requirements and execute the test suite with pytest:
+
+```bash
+pip install -r requirements.txt
+pytest
+```
+
+## Contribution Tips
+
+- Keep functions small and focused.
+- Document new modules and public functions with docstrings.
+- Update or add tests when you change behaviour.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,61 @@
+# Setup
+
+These instructions describe how to configure the project locally and run all services.
+
+## Prerequisites
+
+- Python 3.11+
+- Node.js (for the optional frontend)
+- Docker and Docker Compose (for the full stack example)
+
+Clone the repository and create a virtual environment:
+
+```bash
+git clone <repo-url>
+cd scraper
+python -m venv .venv
+source .venv/bin/activate
+```
+
+Install the Python dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Copy the sample environment file and adjust values as needed:
+
+```bash
+cp .env.example .env
+```
+
+Install frontend dependencies (optional):
+
+```bash
+cd business_intel_scraper/frontend
+npm install
+cd ../../
+```
+
+## Running the full stack with Docker Compose
+
+The repository ships with a `docker-compose.yml` in `business_intel_scraper/`.
+It starts the FastAPI backend and a Celery worker. Redis must be available for
+Celery. The quickest way to launch everything is:
+
+```bash
+docker run -d -p 6379:6379 --name redis redis:7
+cd business_intel_scraper
+docker compose up --build
+```
+
+The API will be available on [http://localhost:8000](http://localhost:8000).
+To serve the frontend, start its dev server in another terminal:
+
+```bash
+cd business_intel_scraper/frontend
+npm start
+```
+
+You can now access the frontend on [http://localhost:8000](http://localhost:8000)
+while the backend handles API requests.


### PR DESCRIPTION
## Summary
- create `docs/` directory with new documentation
- describe setup steps and running the full stack
- document available API endpoints
- add developer guide

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and InvalidRequestError)*

------
https://chatgpt.com/codex/tasks/task_e_6878ec532fa083339ce8432ccea2fb92