### PR TITLE
Implement rate limit middleware

### DIFF
--- a/business_intel_scraper/backend/security/__init__.py
+++ b/business_intel_scraper/backend/security/__init__.py
@@ -2,5 +2,12 @@
 
 from .auth import verify_token
 from .captcha import CaptchaSolver, HTTPCaptchaSolver, solve_captcha
+from .rate_limit import RateLimitMiddleware
 
-__all__ = ["verify_token", "solve_captcha", "CaptchaSolver", "HTTPCaptchaSolver"]
+__all__ = [
+    "verify_token",
+    "solve_captcha",
+    "CaptchaSolver",
+    "HTTPCaptchaSolver",
+    "RateLimitMiddleware",
+]

--- a/business_intel_scraper/backend/security/rate_limit.py
+++ b/business_intel_scraper/backend/security/rate_limit.py
@@ -1,0 +1,40 @@
+"""Request rate limiting middleware."""
+
+from __future__ import annotations
+
+from collections import defaultdict, deque
+from time import time
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.status import HTTP_429_TOO_MANY_REQUESTS
+
+
+class RateLimitMiddleware(BaseHTTPMiddleware):
+    """Limit requests per IP or user using a sliding window."""
+
+    def __init__(self, app, limit: int = 60, window: int = 60) -> None:
+        super().__init__(app)
+        self.limit = limit
+        self.window = window
+        self._requests: dict[str, deque[float]] = defaultdict(deque)
+
+    def _key(self, request: Request) -> str:
+        user = request.headers.get("Authorization")
+        if user:
+            return f"user:{user}"
+        client_ip = request.client.host
+        return f"ip:{client_ip}"
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        key = self._key(request)
+        now = time()
+        history = self._requests[key]
+        cutoff = now - self.window
+        while history and history[0] <= cutoff:
+            history.popleft()
+        if len(history) >= self.limit:
+            return Response("Too Many Requests", status_code=HTTP_429_TOO_MANY_REQUESTS)
+        history.append(now)
+        return await call_next(request)

--- a/business_intel_scraper/backend/tests/test_rate_limit.py
+++ b/business_intel_scraper/backend/tests/test_rate_limit.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from business_intel_scraper.backend.api.rate_limit import RateLimitMiddleware
+from business_intel_scraper.backend.security.rate_limit import RateLimitMiddleware
 
 
 def create_test_app(limit: int = 2) -> TestClient:


### PR DESCRIPTION
## Summary
- add sliding window rate limiter middleware
- re-export middleware in `backend.security`
- update tests to import middleware from new module

## Testing
- `python -m pytest business_intel_scraper/backend/tests/test_rate_limit.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6878ec5209388333801213e330b327ff