### PR TITLE
Add Dockerfiles for API and Celery worker

### DIFF
--- a/business_intel_scraper/infra/docker/api/Dockerfile
+++ b/business_intel_scraper/infra/docker/api/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+# Install Python dependencies
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+# Copy source code
+WORKDIR /app
+COPY . /app
+
+EXPOSE 8000
+
+CMD ["uvicorn", "business_intel_scraper.backend.api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/business_intel_scraper/infra/docker/worker/Dockerfile
+++ b/business_intel_scraper/infra/docker/worker/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.11-slim
+
+# Install Python dependencies
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+# Copy source code
+WORKDIR /app
+COPY . /app
+
+CMD ["celery", "-A", "business_intel_scraper.backend.workers.tasks.celery_app", "worker", "--loglevel=info"]


### PR DESCRIPTION
## Summary
- add dedicated Dockerfile for the FastAPI app
- add Dockerfile for running the Celery worker

## Testing
- `pytest -q` *(fails: NameError: name 'time' is not defined and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6878ec4c0844833394994c539a11f26a