### PR TITLE
Integrate text cleaning into NLP pipeline

### DIFF
--- a/business_intel_scraper/backend/nlp/pipeline.py
+++ b/business_intel_scraper/backend/nlp/pipeline.py
@@ -17,6 +17,7 @@ except ModuleNotFoundError:  # pragma: no cover
 
         pass
 
+
 _NLP_MODEL: Language | None = None
 
 
@@ -36,15 +37,15 @@ def _get_nlp() -> Language | None:
 def extract_entities(texts: Iterable[str]) -> list[str]:
     """Extract named entities from text collection."""
 
-
+    processed = preprocess(texts)
     nlp = _get_nlp()
     entities: list[str] = []
     if nlp is None:
-        for text in texts:
+        for text in processed:
             entities.extend(text.split())
         return entities
 
-    for doc in nlp.pipe(texts):
+    for doc in nlp.pipe(processed):
         found = [ent.text for ent in getattr(doc, "ents", [])]
         if found:
             entities.extend(found)

--- a/business_intel_scraper/backend/tests/test_entity_extraction.py
+++ b/business_intel_scraper/backend/tests/test_entity_extraction.py
@@ -30,3 +30,11 @@ def test_extract_entities_with_stub_nlp(monkeypatch) -> None:
     pipeline._NLP_MODEL = None
     result = pipeline.extract_entities(["Apple was founded", "No entity here"])
     assert result == ["Apple", "No", "entity", "here"]
+
+
+def test_extract_entities_cleans_html(monkeypatch) -> None:
+    """HTML content is stripped before tokenization."""
+    monkeypatch.setattr(pipeline, "_get_nlp", lambda: None)
+    pipeline._NLP_MODEL = None
+    result = pipeline.extract_entities(["<p>Hello <b>World</b></p>"])
+    assert result == ["Hello", "World"]


### PR DESCRIPTION
## Summary
- ensure NLP entity extraction cleans raw text
- test that extraction handles HTML

## Testing
- `PYTHONPATH=. pytest business_intel_scraper/backend/tests/test_text_cleaning.py business_intel_scraper/backend/tests/test_entity_extraction.py business_intel_scraper/backend/tests/test_nlp_pipeline.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6878ec4604c88333b31aa510e2a80397