### PR TITLE
Add React job pages with live updates

### DIFF
--- a/business_intel_scraper/frontend/README.md
+++ b/business_intel_scraper/frontend/README.md
@@ -17,3 +17,21 @@ npm start
 ```
 
 The server runs on [http://localhost:8000](http://localhost:8000) by default.
+
+## Building and running
+
+No build step is required. The development server simply serves the files from
+the `public` directory. Install dependencies once and then start the server:
+
+```bash
+npm install
+npm start
+```
+
+During development the frontend expects the FastAPI backend to be running on the
+same host and port. Start the API with `uvicorn` or via Docker Compose and then
+open [http://localhost:8000](http://localhost:8000) in your browser.
+
+The application communicates with the backend using the REST endpoints defined
+in `docs/api_usage.md` and listens for real time updates on the
+`/ws/notifications` WebSocket and `/logs/stream` SSE endpoint.

--- a/business_intel_scraper/frontend/public/index.html
+++ b/business_intel_scraper/frontend/public/index.html
@@ -6,6 +6,7 @@
     <title>Business Intel Scraper</title>
     <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react-router-dom@6/umd/react-router-dom.production.min.js"></script>
     <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
   </head>
   <body>

--- a/business_intel_scraper/frontend/src/index.js
+++ b/business_intel_scraper/frontend/src/index.js
@@ -1,30 +1,25 @@
-function App() {
-  const [data, setData] = React.useState([]);
-  const [jobs, setJobs] = React.useState({});
-  const loadData = () => {
-    fetch('/data')
-      .then((res) => res.json())
-      .then(setData)
-      .catch(() => {});
-    fetch('/jobs')
-      .then((res) => res.json())
-      .then(setJobs)
-      .catch(() => {});
-  };
+const { BrowserRouter, Routes, Route, Link } = ReactRouterDOM;
 
-  React.useEffect(loadData, []);
-
+function ResultsPage({ data, refresh }) {
   return (
     <div style={{ fontFamily: 'sans-serif' }}>
       <h1>Scraped Results</h1>
-      <button onClick={loadData}>Refresh</button>
+      <button onClick={refresh}>Refresh</button>
       <ul>
         {data.map((item, idx) => (
           <li key={idx}>{JSON.stringify(item)}</li>
         ))}
       </ul>
+    </div>
+  );
+}
 
-      <h2>Job Status</h2>
+function JobsPage({ jobs, refresh, startJob, logs }) {
+  return (
+    <div style={{ fontFamily: 'sans-serif' }}>
+      <h1>Job Management</h1>
+      <button onClick={refresh}>Refresh</button>
+      <button onClick={startJob}>Start Job</button>
       <ul>
         {Object.entries(jobs).map(([id, job]) => (
           <li key={id}>
@@ -32,7 +27,76 @@ function App() {
           </li>
         ))}
       </ul>
+      <h2>Logs</h2>
+      <pre style={{ maxHeight: '200px', overflow: 'auto', background: '#eee', padding: '0.5rem' }}>
+        {logs.join('\n')}
+      </pre>
     </div>
+  );
+}
+
+function App() {
+  const [data, setData] = React.useState([]);
+  const [jobs, setJobs] = React.useState({});
+  const [logs, setLogs] = React.useState([]);
+
+  const loadData = () => {
+    fetch('/data')
+      .then((res) => res.json())
+      .then(setData)
+      .catch(() => {});
+  };
+
+  const loadJobs = () => {
+    fetch('/jobs')
+      .then((res) => res.json())
+      .then(setJobs)
+      .catch(() => {});
+  };
+
+  const startJob = () => {
+    fetch('/scrape', { method: 'POST' })
+      .then((res) => res.json())
+      .then((res) => {
+        setJobs((j) => ({ ...j, [res.task_id]: { status: 'running' } }));
+      })
+      .catch(() => {});
+  };
+
+  React.useEffect(() => {
+    loadData();
+    loadJobs();
+  }, []);
+
+  React.useEffect(() => {
+    const wsProtocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
+    const ws = new WebSocket(`${wsProtocol}://${window.location.host}/ws/notifications`);
+    ws.onmessage = (e) => {
+      try {
+        const msg = JSON.parse(e.data);
+        setJobs((j) => ({ ...j, [msg.job_id]: { status: msg.status } }));
+      } catch {}
+    };
+    const es = new EventSource('/logs/stream');
+    es.onmessage = (e) => {
+      setLogs((l) => [...l.slice(-99), e.data]);
+    };
+    return () => {
+      ws.close();
+      es.close();
+    };
+  }, []);
+
+  return (
+    <BrowserRouter>
+      <nav style={{ marginBottom: '1rem' }}>
+        <Link to="/results">Results</Link> | <Link to="/jobs">Jobs</Link>
+      </nav>
+      <Routes>
+        <Route path="/jobs" element={<JobsPage jobs={jobs} refresh={loadJobs} startJob={startJob} logs={logs} />} />
+        <Route path="/*" element={<ResultsPage data={data} refresh={loadData} />} />
+      </Routes>
+    </BrowserRouter>
   );
 }
 


### PR DESCRIPTION
## Summary
- expand frontend to use React Router with pages for job management and results
- connect to WebSocket notifications and SSE log streaming
- document build and run steps for the frontend

## Testing
- `pytest -q` *(fails: 15 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6879833eda2883339fb0ce48be80c1f7