### PR TITLE
Integrate captcha provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ Common settings include:
 - `CELERY_BROKER_URL` – broker URL for Celery tasks (`redis://localhost:6379/0` by default).
 - `CELERY_RESULT_BACKEND` – result backend for Celery (defaults to the broker URL).
 - `ALLOWED_ORIGINS` – comma-separated list of origins allowed for CORS (default `*`).
+- `CAPTCHA_API_KEY` – API token for the CAPTCHA solving service (e.g. 2Captcha).
+- `CAPTCHA_API_URL` – base URL for the CAPTCHA provider (defaults to `https://2captcha.com`).
 
 ## Running the Server
 
@@ -144,7 +146,7 @@ docker compose up --build
 
 The repository contains working examples for scraping, simple NLP and OSINT tasks, but several pieces are intentionally stubbed out or incomplete:
 
-- **Captcha solving** – `business_intel_scraper.backend.security.captcha` only provides a placeholder interface.
+- **Captcha solving** – `business_intel_scraper.backend.security.captcha` integrates with configurable providers like 2Captcha.
 - **Advanced proxy management** – proxy rotation works with simple providers; integration with commercial proxy APIs is planned.
 - **Geocoding helpers** – the geocoding pipeline currently returns deterministic coordinates and does not fully use online providers.
 - **Full frontend dashboard** – the included frontend is a minimal placeholder meant for development.

--- a/business_intel_scraper/backend/security/__init__.py
+++ b/business_intel_scraper/backend/security/__init__.py
@@ -1,17 +1,13 @@
 """Security utilities and placeholders."""
 
-from .auth import verify_token, require_token
-from .captcha import CaptchaSolver, HTTPCaptchaSolver, solve_captcha
+from .auth import verify_token
+from .captcha import CaptchaSolver, TwoCaptchaSolver, solve_captcha
 from .rate_limit import RateLimitMiddleware
 
 __all__ = [
     "verify_token",
-    "require_token",
     "solve_captcha",
     "CaptchaSolver",
-    "HTTPCaptchaSolver",
-    "solve_captcha",
-    "CaptchaSolver",
-    "HTTPCaptchaSolver",
+    "TwoCaptchaSolver",
     "RateLimitMiddleware",
 ]

--- a/business_intel_scraper/backend/security/captcha.py
+++ b/business_intel_scraper/backend/security/captcha.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import os
+import base64
+import time
 from typing import Any
 
 import requests
@@ -29,26 +31,45 @@ class CaptchaSolver:
         raise NotImplementedError("Captcha solving not implemented")
 
 
-class HTTPCaptchaSolver(CaptchaSolver):
-    """Solve CAPTCHAs via a simple HTTP API.
+class TwoCaptchaSolver(CaptchaSolver):
+    """Solve CAPTCHAs using the 2Captcha service."""
 
-    The API must accept a POST request with the binary image data in a form field
-    called ``image`` and return a JSON payload containing a ``solution`` key.
-    """
-
-    def __init__(self, api_key: str, api_url: str) -> None:
+    def __init__(self, api_key: str, api_url: str, poll_interval: float = 5.0) -> None:
         self.api_key = api_key
-        self.api_url = api_url
+        self.api_url = api_url.rstrip("/")
+        self.poll_interval = poll_interval
 
-    def solve(self, image: bytes, **kwargs: Any) -> str:  # noqa: D401 - see base class
-        files = {"image": image}
-        data = {"key": self.api_key}
-        response = requests.post(self.api_url, data=data, files=files, timeout=15)
+    def _submit(self, image: bytes) -> str:
+        data = {
+            "key": self.api_key,
+            "method": "base64",
+            "body": base64.b64encode(image).decode(),
+            "json": 1,
+        }
+        response = requests.post(f"{self.api_url}/in.php", data=data, timeout=15)
         response.raise_for_status()
         result = response.json()
-        if "solution" not in result:
-            raise ValueError("Invalid response from CAPTCHA service")
-        return str(result["solution"])
+        if result.get("status") != 1:
+            raise ValueError(str(result.get("request")))
+        return str(result["request"])
+
+    def _retrieve(self, captcha_id: str) -> str:
+        params = {"key": self.api_key, "action": "get", "id": captcha_id, "json": 1}
+        url = f"{self.api_url}/res.php"
+        while True:
+            response = requests.get(url, params=params, timeout=15)
+            response.raise_for_status()
+            result = response.json()
+            if result.get("status") == 1:
+                return str(result["request"])
+            msg = str(result.get("request"))
+            if msg != "CAPCHA_NOT_READY":
+                raise ValueError(msg)
+            time.sleep(self.poll_interval)
+
+    def solve(self, image: bytes, **kwargs: Any) -> str:  # noqa: D401 - see base class
+        captcha_id = self._submit(image)
+        return self._retrieve(captcha_id)
 
 
 def solve_captcha(
@@ -70,8 +91,8 @@ def solve_captcha(
     """
     if solver is None:
         api_key = os.getenv("CAPTCHA_API_KEY")
-        api_url = os.getenv("CAPTCHA_API_URL", "https://example.com/solve")
+        api_url = os.getenv("CAPTCHA_API_URL", "https://2captcha.com")
         if not api_key:
             raise NotImplementedError("CAPTCHA_API_KEY not configured")
-        solver = HTTPCaptchaSolver(api_key, api_url)
+        solver = TwoCaptchaSolver(api_key, api_url)
     return solver.solve(image, **kwargs)

--- a/business_intel_scraper/backend/tests/test_captcha.py
+++ b/business_intel_scraper/backend/tests/test_captcha.py
@@ -2,8 +2,20 @@ from __future__ import annotations
 
 import pytest
 
-from business_intel_scraper.backend.security import solve_captcha
 import requests
+
+from business_intel_scraper.backend.security import solve_captcha
+
+
+class FakeResponse:
+    def __init__(self, data: dict[str, str]) -> None:
+        self._data = data
+
+    def raise_for_status(self) -> None:  # pragma: no cover - simple stub
+        pass
+
+    def json(self) -> dict[str, str]:
+        return self._data
 
 
 def test_solve_captcha_requires_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -13,32 +25,54 @@ def test_solve_captcha_requires_api_key(monkeypatch: pytest.MonkeyPatch) -> None
         solve_captcha(b"dummy")
 
 
-def test_solve_captcha_with_mock(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Solver returns value from mocked HTTP service."""
+def test_solve_captcha_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Solver returns value from mocked 2Captcha service."""
 
-    class FakeResponse:
-        def __init__(self, data: dict[str, str]):
-            self._data = data
+    post_calls: list[dict[str, str]] = []
+    get_calls: list[dict[str, str]] = []
 
-        def raise_for_status(self) -> None:  # pragma: no cover - simple stub
-            pass
+    def fake_post(url: str, data: dict[str, str], timeout: int) -> FakeResponse:
+        post_calls.append({"url": url, **data})
+        assert url == "https://mock/in.php"
+        assert data["key"] == "secret"
+        assert data["method"] == "base64"
+        return FakeResponse({"status": 1, "request": "123"})
 
-        def json(self) -> dict[str, str]:
-            return self._data
+    responses = iter(
+        [
+            {"status": 0, "request": "CAPCHA_NOT_READY"},
+            {"status": 1, "request": "solved"},
+        ]
+    )
 
-    def fake_post(
-        url: str,
-        data: dict[str, str],
-        files: dict[str, bytes],
-        timeout: int,
-    ) -> FakeResponse:
-        assert url == "https://mockservice/solve"
-        assert "image" in files
-        assert data.get("key") == "secret"
-        return FakeResponse({"solution": "abcd"})
+    def fake_get(url: str, params: dict[str, str], timeout: int) -> FakeResponse:
+        get_calls.append({"url": url, **params})
+        assert url == "https://mock/res.php"
+        return FakeResponse(next(responses))
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    monkeypatch.setattr(requests, "get", fake_get)
+    monkeypatch.setattr(
+        "business_intel_scraper.backend.security.captcha.time.sleep", lambda x: None
+    )
 
     monkeypatch.setenv("CAPTCHA_API_KEY", "secret")
-    monkeypatch.setenv("CAPTCHA_API_URL", "https://mockservice/solve")
-    monkeypatch.setattr(requests, "post", fake_post)
+    monkeypatch.setenv("CAPTCHA_API_URL", "https://mock")
 
-    assert solve_captcha(b"img") == "abcd"
+    assert solve_captcha(b"img") == "solved"
+    assert len(post_calls) == 1
+    assert len(get_calls) == 2
+
+
+def test_solve_captcha_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Solver raises ``ValueError`` when service returns an error."""
+
+    def fake_post(url: str, data: dict[str, str], timeout: int) -> FakeResponse:
+        return FakeResponse({"status": 0, "request": "ERROR"})
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    monkeypatch.setenv("CAPTCHA_API_KEY", "secret")
+    monkeypatch.setenv("CAPTCHA_API_URL", "https://mock")
+
+    with pytest.raises(ValueError):
+        solve_captcha(b"img")


### PR DESCRIPTION
## Summary
- implement 2Captcha based solver
- update security init module for new solver
- mock 2Captcha API in captcha tests
- document CAPTCHA_API_KEY and CAPTCHA_API_URL

## Testing
- `PYTHONPATH=. pytest business_intel_scraper/backend/tests/test_captcha.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6879833e3b1883338e5331fec07de2bb