### PR TITLE
Add Celery beat schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,11 @@ If background tasks are used, run a Celery worker in a separate terminal:
 ```bash
 celery -A business_intel_scraper.backend.workers.tasks.celery_app worker --loglevel=info
 ```
+To run scrapes automatically on a schedule, start Celery beat:
+
+```bash
+celery -A business_intel_scraper.backend.workers.tasks.celery_app beat --loglevel=info
+```
 
 With the services running you can interact with the API:
 

--- a/business_intel_scraper/backend/osint/integrations.py
+++ b/business_intel_scraper/backend/osint/integrations.py
@@ -111,8 +111,7 @@ def run_subfinder(domain: str) -> dict[str, str]:
     return {"domain": domain, "output": output}
 
 
-def run_theharvester(domain: str) -> dict[str, str]:
-
+def run_theharvester(domain: str, parse_output: bool = False) -> dict[str, str]:
     """Run TheHarvester against a domain.
 
     Similar to :func:`run_spiderfoot`, this wrapper relies on the presence of

--- a/business_intel_scraper/backend/tests/test_celery_schedule.py
+++ b/business_intel_scraper/backend/tests/test_celery_schedule.py
@@ -1,0 +1,18 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+)
+
+tasks = pytest.importorskip("business_intel_scraper.backend.workers.tasks")
+
+
+def test_periodic_task_registered() -> None:
+    assert "example_spider_hourly" in tasks.celery_app.conf.beat_schedule
+    entry = tasks.celery_app.conf.beat_schedule["example_spider_hourly"]
+    assert (
+        entry["task"]
+        == "business_intel_scraper.backend.workers.tasks.scheduled_example_scrape"
+    )

--- a/business_intel_scraper/backend/workers/tasks.py
+++ b/business_intel_scraper/backend/workers/tasks.py
@@ -27,6 +27,7 @@ from business_intel_scraper.backend.osint.integrations import (
 from business_intel_scraper.backend.nlp import pipeline
 from business_intel_scraper.backend.geo.processing import geocode_addresses
 from ..audit.logger import log_job_start, log_job_finish, log_job_error
+from celery.schedules import crontab
 
 
 try:
@@ -69,6 +70,13 @@ try:  # pragma: no cover - optional dependency
     )
 except ModuleNotFoundError:
     pass
+
+celery_app.conf.beat_schedule = {
+    "example_spider_hourly": {
+        "task": "business_intel_scraper.backend.workers.tasks.scheduled_example_scrape",
+        "schedule": crontab(minute=0, hour="*"),
+    }
+}
 
 
 try:
@@ -159,6 +167,14 @@ def _run_example_spider(job_id: str) -> str:
     log_job_finish(job_id)
     TASK_DURATION.labels(task="example_spider").observe(time.perf_counter() - start)
     return "scraping complete"
+
+
+@celery_app.task
+def scheduled_example_scrape() -> str:
+    """Periodically run the example spider and persist data."""
+    job_id = str(uuid.uuid4())
+    _run_example_spider(job_id)
+    return job_id
 
 
 def launch_scraping_task() -> str:

--- a/business_intel_scraper/infra/docker/docker-compose.yml
+++ b/business_intel_scraper/infra/docker/docker-compose.yml
@@ -22,3 +22,15 @@ services:
       - ../../:/app
     depends_on:
       - api
+
+  beat:
+    build:
+      context: ../../..
+      dockerfile: business_intel_scraper/infra/docker/worker/Dockerfile
+    command: celery -A business_intel_scraper.backend.workers.tasks.celery_app beat --loglevel=info -s /tmp/celerybeat-schedule
+    env_file:
+      - ../../.env
+    volumes:
+      - ../../:/app
+    depends_on:
+      - api

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,21 @@ services:
     networks:
       - backend
 
+  beat:
+    build: .
+    command: celery -A business_intel_scraper.backend.workers.tasks.celery_app beat --loglevel=info -s /tmp/celerybeat-schedule
+    environment:
+      DATABASE_URL: postgresql://postgres:postgres@db:5432/postgres
+      CELERY_BROKER_URL: redis://redis:6379/0
+      CELERY_RESULT_BACKEND: redis://redis:6379/0
+    volumes:
+      - .:/app
+    depends_on:
+      - db
+      - redis
+    networks:
+      - backend
+
   db:
     image: postgres:15
     environment:


### PR DESCRIPTION
## Summary
- add periodic task `scheduled_example_scrape`
- configure Celery beat to run hourly
- update docker compose files with a `beat` service
- document running Celery beat
- test for beat schedule
- expose parse_output flag for TheHarvester helper

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'business_intel_scraper')*

------
https://chatgpt.com/codex/tasks/task_e_687987baef508333838ea18d8fca490d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automated, scheduled execution of the example spider every hour via a new periodic Celery task.
  * Added Celery beat scheduler service to Docker Compose configurations for both local and infrastructure environments.

* **Documentation**
  * Updated README with instructions for running Celery beat alongside the worker to enable scheduled scrapes.

* **Bug Fixes**
  * None.

* **Tests**
  * Added tests to verify correct registration of the periodic Celery task in the schedule.

* **Other Improvements**
  * Enhanced an integration function with an optional output parsing parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->