### PR TITLE
Add API CLI client

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,16 @@ curl -X POST http://localhost:8000/scrape # launch the example spider
 
 Task progress can be queried at `/tasks/<task_id>` and log messages stream from `/logs/stream`.
 
+### Command Line Client
+
+A small CLI is included for interacting with the API. It defaults to http://localhost:8000 and reads a bearer token from the BI_SCRAPER_TOKEN environment variable.
+
+```bash
+python -m business_intel_scraper.cli scrape       # launch a job
+python -m business_intel_scraper.cli status <id>  # check status
+python -m business_intel_scraper.cli download -o results.json
+```
+
 The repository also provides a `docker-compose.yml` in `business_intel_scraper/` for launching Redis, the API and a worker together:
 
 ```bash

--- a/business_intel_scraper/backend/osint/integrations.py
+++ b/business_intel_scraper/backend/osint/integrations.py
@@ -111,8 +111,7 @@ def run_subfinder(domain: str) -> dict[str, str]:
     return {"domain": domain, "output": output}
 
 
-def run_theharvester(domain: str) -> dict[str, str]:
-
+def run_theharvester(domain: str, parse_output: bool = False) -> dict[str, str]:
     """Run TheHarvester against a domain.
 
     Similar to :func:`run_spiderfoot`, this wrapper relies on the presence of

--- a/business_intel_scraper/cli.py
+++ b/business_intel_scraper/cli.py
@@ -1,0 +1,72 @@
+"""Simple command line client for the BI scraper API."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+import httpx
+
+
+DEFAULT_URL = os.getenv("BI_SCRAPER_URL", "http://localhost:8000")
+DEFAULT_TOKEN = os.getenv("BI_SCRAPER_TOKEN", "")
+
+
+def _headers(token: str) -> dict[str, str]:
+    if token:
+        return {"Authorization": f"Bearer {token}"}
+    return {}
+
+
+def start_scrape(url: str, token: str) -> None:
+    resp = httpx.post(f"{url}/scrape", headers=_headers(token))
+    resp.raise_for_status()
+    print(resp.json()["task_id"])
+
+
+def check_status(url: str, token: str, task_id: str) -> None:
+    resp = httpx.get(f"{url}/tasks/{task_id}", headers=_headers(token))
+    resp.raise_for_status()
+    print(resp.json()["status"])
+
+
+def download_data(url: str, token: str, output: str | None) -> None:
+    resp = httpx.get(f"{url}/data", headers=_headers(token))
+    resp.raise_for_status()
+    data = resp.json()
+    if output:
+        Path(output).write_text(json.dumps(data, indent=2))
+    else:
+        print(json.dumps(data, indent=2))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Interact with the Business Intelligence Scraper API"
+    )
+    parser.add_argument("--url", default=DEFAULT_URL, help="API base URL")
+    parser.add_argument("--token", default=DEFAULT_TOKEN, help="Bearer token")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("scrape", help="Launch a scraping job")
+
+    stat = sub.add_parser("status", help="Check job status")
+    stat.add_argument("task_id")
+
+    dl = sub.add_parser("download", help="Download scraped data")
+    dl.add_argument("-o", "--output")
+
+    args = parser.parse_args()
+
+    if args.cmd == "scrape":
+        start_scrape(args.url, args.token)
+    elif args.cmd == "status":
+        check_status(args.url, args.token, args.task_id)
+    elif args.cmd == "download":
+        download_data(args.url, args.token, args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement a small API client under `business_intel_scraper.cli`
- update TheHarvester wrapper with `parse_output` parameter
- document the new command line tool in README

## Testing
- `ruff check`
- `black business_intel_scraper/backend/osint/integrations.py business_intel_scraper/cli.py`
- `pytest -q` *(fails: cannot import `HTTPCaptchaSolver`)*

------
https://chatgpt.com/codex/tasks/task_e_687987bee4408333b3957213f54a3dbe