### PR TITLE
Implement requests caching layer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,7 @@ PROXY_URL=
 CELERY_BROKER_URL=redis://localhost:6379/0
 CELERY_RESULT_BACKEND=redis://localhost:6379/0
 ALLOWED_ORIGINS=http://localhost:3000
+CACHE_BACKEND=filesystem
+# CACHE_REDIS_URL=redis://localhost:6379/1
+# CACHE_DIR=http_cache
+# CACHE_EXPIRE=3600

--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ Common settings include:
 - `ALLOWED_ORIGINS` – comma-separated list of origins allowed for CORS (default `*`).
 - `CAPTCHA_API_KEY` – API token for the CAPTCHA solving service (e.g. 2Captcha).
 - `CAPTCHA_API_URL` – base URL for the CAPTCHA provider (defaults to `https://2captcha.com`).
+- `CACHE_BACKEND` – set to `redis` or `filesystem` to enable request caching.
+- `CACHE_REDIS_URL` – Redis connection URL when using the Redis backend.
+- `CACHE_DIR` – directory used for the filesystem cache.
+- `CACHE_EXPIRE` – cache expiration time in seconds (default `3600`).
 
 ## Proxy Configuration
 

--- a/business_intel_scraper/backend/tests/test_request_cache.py
+++ b/business_intel_scraper/backend/tests/test_request_cache.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+import requests_cache
+
+from business_intel_scraper.backend.utils.cache import setup_request_cache
+
+
+def test_setup_request_cache_filesystem(tmp_path, monkeypatch):
+    monkeypatch.setenv("CACHE_BACKEND", "filesystem")
+    monkeypatch.setenv("CACHE_DIR", str(tmp_path))
+    monkeypatch.delenv("CACHE_REDIS_URL", raising=False)
+    setup_request_cache()
+    cache = requests_cache.get_cache()
+    assert isinstance(cache, requests_cache.backends.filesystem.FileCache)
+    assert Path(cache.cache_dir).parent == tmp_path
+    requests_cache.uninstall_cache()

--- a/business_intel_scraper/backend/utils/__init__.py
+++ b/business_intel_scraper/backend/utils/__init__.py
@@ -2,5 +2,6 @@
 
 from .helpers import setup_logging
 from .proxy_manager import ProxyManager
+from .cache import setup_request_cache
 
-__all__ = ["setup_logging", "ProxyManager"]
+__all__ = ["setup_logging", "ProxyManager", "setup_request_cache"]

--- a/business_intel_scraper/backend/utils/cache.py
+++ b/business_intel_scraper/backend/utils/cache.py
@@ -1,0 +1,42 @@
+"""HTTP request caching helpers."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import requests_cache
+
+
+_DEF_EXPIRE = 3600
+
+
+def setup_request_cache() -> None:
+    """Configure a requests cache using Redis or the filesystem."""
+
+    backend = os.getenv("CACHE_BACKEND", "filesystem").lower()
+    expire = int(os.getenv("CACHE_EXPIRE", str(_DEF_EXPIRE)))
+
+    if backend == "redis":
+        redis_url = os.getenv("CACHE_REDIS_URL", "redis://localhost:6379/1")
+        try:
+            from redis import from_url as redis_from_url
+        except Exception as exc:  # pragma: no cover - import error tested indirectly
+            raise RuntimeError(
+                "Redis backend requested but redis package missing"
+            ) from exc
+
+        requests_cache.install_cache(
+            "bi_cache",
+            backend="redis",
+            connection=redis_from_url(redis_url),
+            expire_after=expire,
+        )
+    else:
+        cache_dir = Path(os.getenv("CACHE_DIR", "http_cache"))
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        requests_cache.install_cache(
+            str(cache_dir / "requests_cache"),
+            backend="filesystem",
+            expire_after=expire,
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,5 @@ pyjwt
 passlib
 prometheus-client
 gevent
-
+requests-cache
+redis

--- a/settings.py
+++ b/settings.py
@@ -61,6 +61,16 @@ class CelerySettings:
 
 
 @dataclass
+class CacheSettings:
+    """HTTP request caching settings."""
+
+    backend: str = os.getenv("CACHE_BACKEND", "filesystem")
+    expire: int = int(os.getenv("CACHE_EXPIRE", "3600"))
+    redis_url: str = os.getenv("CACHE_REDIS_URL", "redis://localhost:6379/1")
+    cache_dir: str = os.getenv("CACHE_DIR", "http_cache")
+
+
+@dataclass
 class Settings:
     """Container for all application settings."""
 
@@ -69,6 +79,7 @@ class Settings:
     proxy: ProxySettings = field(default_factory=ProxySettings)
     rate_limit: RateLimitSettings = field(default_factory=RateLimitSettings)
     celery: CelerySettings = field(default_factory=CelerySettings)
+    cache: CacheSettings = field(default_factory=CacheSettings)
     require_https: bool = os.getenv("USE_HTTPS", "false").lower() == "true"
 
 


### PR DESCRIPTION
## Summary
- add requests-cache dependency and redis optional dependency
- provide `setup_request_cache` helper to install a cache
- expose new helper via `backend.utils`
- document cache settings in README and `.env.example`
- add test for filesystem cache setup

## Testing
- `black business_intel_scraper/backend/tests/test_request_cache.py business_intel_scraper/backend/utils/cache.py settings.py business_intel_scraper/backend/utils/__init__.py`
- `ruff check business_intel_scraper/backend/utils/cache.py business_intel_scraper/backend/tests/test_request_cache.py business_intel_scraper/backend/utils/__init__.py settings.py`
- `PYTHONPATH=. pytest business_intel_scraper/backend/tests/test_request_cache.py -q`


------
https://chatgpt.com/codex/tasks/task_e_687987d592a48333a87059e8ecd0e9aa