### PR TITLE
Add spider module stubs

### DIFF
--- a/business_intel_scraper/backend/spiders/__init__.py
+++ b/business_intel_scraper/backend/spiders/__init__.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from .company_registry_spider import CompanyRegistrySpider
+from .social_media_profile_spider import SocialMediaProfileSpider
+from .news_article_spider import NewsArticleSpider
+from .job_listings_spider import JobListingsSpider
+from .industry_reports_spider import IndustryReportsSpider
+from .financial_filings_spider import FinancialFilingsSpider
+from .government_contract_portal_spider import GovernmentContractPortalSpider
+from .company_blog_spider import CompanyBlogSpider
+from .conference_events_spider import ConferenceEventsSpider
+from .geographic_directory_spider import GeographicDirectorySpider
+from .product_review_spider import ProductReviewSpider
+from .real_estate_listing_spider import RealEstateListingSpider
+from .grant_or_funding_database_spider import GrantOrFundingDatabaseSpider
+from .security_advisory_spider import SecurityAdvisorySpider
+from .corporate_officer_spider import CorporateOfficerSpider
+from .patent_trademark_spider import PatentTrademarkSpider
+from .financial_news_spider import FinancialNewsSpider
+from .public_record_spider import PublicRecordSpider
+from .supply_chain_spider import SupplyChainSpider
+from .competitor_price_spider import CompetitorPriceSpider
+from .sanctions_and_watchlist_spider import SanctionsWatchlistSpider
+from .environmental_violation_spider import EnvironmentalViolationSpider
+from .litigation_and_lawsuit_spider import LitigationLawsuitSpider
+from .permits_and_licensing_spider import PermitsLicensingSpider
+from .bankruptcy_filings_spider import BankruptcyFilingsSpider
+from .tax_lien_spider import TaxLienSpider
+from .crowdfunding_platform_spider import CrowdfundingPlatformSpider
+from .employee_review_spider import EmployeeReviewSpider
+from .logistics_and_shipping_spider import LogisticsShippingSpider
+from .facility_plant_location_spider import FacilityPlantLocationSpider
+from .vendor_partner_spider import VendorPartnerSpider
+from .website_technology_stack_spider import WebsiteTechnologyStackSpider
+from .app_store_listing_spider import AppStoreListingSpider
+from .open_source_contributions_spider import OpenSourceContributionsSpider
+from .domain_registration_spider import DomainRegistrationSpider
+from .cyber_incident_breach_spider import CyberIncidentBreachSpider
+from .import_export_trade_spider import ImportExportTradeSpider
+from .procurement_bidding_spider import ProcurementBiddingSpider
+from .marketplace_spider import MarketplaceSpider
+from .auction_foreclosure_spider import AuctionForeclosureSpider
+from .consumer_complaint_spider import ConsumerComplaintSpider
+from .lobbyist_registry_spider import LobbyistRegistrySpider
+from .charity_csr_spider import CharityCsrSpider
+from .awards_and_rankings_spider import AwardsRankingsSpider
+from .export_control_list_spider import ExportControlListSpider
+
+__all__ = [
+    "CompanyRegistrySpider",
+    "SocialMediaProfileSpider",
+    "NewsArticleSpider",
+    "JobListingsSpider",
+    "IndustryReportsSpider",
+    "FinancialFilingsSpider",
+    "GovernmentContractPortalSpider",
+    "CompanyBlogSpider",
+    "ConferenceEventsSpider",
+    "GeographicDirectorySpider",
+    "ProductReviewSpider",
+    "RealEstateListingSpider",
+    "GrantOrFundingDatabaseSpider",
+    "SecurityAdvisorySpider",
+    "CorporateOfficerSpider",
+    "PatentTrademarkSpider",
+    "FinancialNewsSpider",
+    "PublicRecordSpider",
+    "SupplyChainSpider",
+    "CompetitorPriceSpider",
+    "SanctionsWatchlistSpider",
+    "EnvironmentalViolationSpider",
+    "LitigationLawsuitSpider",
+    "PermitsLicensingSpider",
+    "BankruptcyFilingsSpider",
+    "TaxLienSpider",
+    "CrowdfundingPlatformSpider",
+    "EmployeeReviewSpider",
+    "LogisticsShippingSpider",
+    "FacilityPlantLocationSpider",
+    "VendorPartnerSpider",
+    "WebsiteTechnologyStackSpider",
+    "AppStoreListingSpider",
+    "OpenSourceContributionsSpider",
+    "DomainRegistrationSpider",
+    "CyberIncidentBreachSpider",
+    "ImportExportTradeSpider",
+    "ProcurementBiddingSpider",
+    "MarketplaceSpider",
+    "AuctionForeclosureSpider",
+    "ConsumerComplaintSpider",
+    "LobbyistRegistrySpider",
+    "CharityCsrSpider",
+    "AwardsRankingsSpider",
+    "ExportControlListSpider",
+]

--- a/business_intel_scraper/backend/spiders/app_store_listing_spider.py
+++ b/business_intel_scraper/backend/spiders/app_store_listing_spider.py
@@ -1,0 +1,13 @@
+"""Harvest company or product listings from Google Play, Apple App Store, or
+regional alternatives."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class AppStoreListingSpider(scrapy.Spider):
+    """Harvest company or product listings from Google Play, Apple App Store, or
+    regional alternatives."""
+
+    name = "app_store_listing_spider"

--- a/business_intel_scraper/backend/spiders/auction_foreclosure_spider.py
+++ b/business_intel_scraper/backend/spiders/auction_foreclosure_spider.py
@@ -1,0 +1,11 @@
+"""Monitor auction or foreclosure notices for business asset liquidation."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class AuctionForeclosureSpider(scrapy.Spider):
+    """Monitor auction or foreclosure notices for business asset liquidation."""
+
+    name = "auction_foreclosure_spider"

--- a/business_intel_scraper/backend/spiders/awards_and_rankings_spider.py
+++ b/business_intel_scraper/backend/spiders/awards_and_rankings_spider.py
@@ -1,0 +1,13 @@
+"""Collect business/industry awards, 'top company' lists, or innovation
+rankings."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class AwardsRankingsSpider(scrapy.Spider):
+    """Collect business/industry awards, 'top company' lists, or innovation
+    rankings."""
+
+    name = "awards_and_rankings_spider"

--- a/business_intel_scraper/backend/spiders/bankruptcy_filings_spider.py
+++ b/business_intel_scraper/backend/spiders/bankruptcy_filings_spider.py
@@ -1,0 +1,11 @@
+"""Monitor bankruptcy or insolvency announcements."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class BankruptcyFilingsSpider(scrapy.Spider):
+    """Monitor bankruptcy or insolvency announcements."""
+
+    name = "bankruptcy_filings_spider"

--- a/business_intel_scraper/backend/spiders/charity_csr_spider.py
+++ b/business_intel_scraper/backend/spiders/charity_csr_spider.py
@@ -1,0 +1,13 @@
+"""Scrape donations, philanthropic initiatives, or CSR activity for company
+social footprint."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class CharityCsrSpider(scrapy.Spider):
+    """Scrape donations, philanthropic initiatives, or CSR activity for company
+    social footprint."""
+
+    name = "charity_csr_spider"

--- a/business_intel_scraper/backend/spiders/company_blog_spider.py
+++ b/business_intel_scraper/backend/spiders/company_blog_spider.py
@@ -1,0 +1,13 @@
+"""Monitor official company blogs or press releases for announcements and
+insights."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class CompanyBlogSpider(scrapy.Spider):
+    """Monitor official company blogs or press releases for announcements and
+    insights."""
+
+    name = "company_blog_spider"

--- a/business_intel_scraper/backend/spiders/company_registry_spider.py
+++ b/business_intel_scraper/backend/spiders/company_registry_spider.py
@@ -1,0 +1,13 @@
+"""Crawl official government or regional business registries for company
+metadata."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class CompanyRegistrySpider(scrapy.Spider):
+    """Crawl official government or regional business registries for company
+    metadata."""
+
+    name = "company_registry_spider"

--- a/business_intel_scraper/backend/spiders/competitor_price_spider.py
+++ b/business_intel_scraper/backend/spiders/competitor_price_spider.py
@@ -1,0 +1,11 @@
+"""Track competitor pricing or product availability from online retailers."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class CompetitorPriceSpider(scrapy.Spider):
+    """Track competitor pricing or product availability from online retailers."""
+
+    name = "competitor_price_spider"

--- a/business_intel_scraper/backend/spiders/conference_events_spider.py
+++ b/business_intel_scraper/backend/spiders/conference_events_spider.py
@@ -1,0 +1,11 @@
+"""Extract event schedules or attendee lists from conference websites."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class ConferenceEventsSpider(scrapy.Spider):
+    """Extract event schedules or attendee lists from conference websites."""
+
+    name = "conference_events_spider"

--- a/business_intel_scraper/backend/spiders/consumer_complaint_spider.py
+++ b/business_intel_scraper/backend/spiders/consumer_complaint_spider.py
@@ -1,0 +1,13 @@
+"""Gather consumer complaints from BBB, Trustpilot, Ripoff Report, or regional
+equivalents."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class ConsumerComplaintSpider(scrapy.Spider):
+    """Gather consumer complaints from BBB, Trustpilot, Ripoff Report, or regional
+    equivalents."""
+
+    name = "consumer_complaint_spider"

--- a/business_intel_scraper/backend/spiders/corporate_officer_spider.py
+++ b/business_intel_scraper/backend/spiders/corporate_officer_spider.py
@@ -1,0 +1,13 @@
+"""Extract leadership or executive details from 'About Us' pages for network
+analysis."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class CorporateOfficerSpider(scrapy.Spider):
+    """Extract leadership or executive details from 'About Us' pages for network
+    analysis."""
+
+    name = "corporate_officer_spider"

--- a/business_intel_scraper/backend/spiders/crowdfunding_platform_spider.py
+++ b/business_intel_scraper/backend/spiders/crowdfunding_platform_spider.py
@@ -1,0 +1,13 @@
+"""Monitor Kickstarter, Indiegogo, or regional platforms for startup signals and
+emerging ventures."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class CrowdfundingPlatformSpider(scrapy.Spider):
+    """Monitor Kickstarter, Indiegogo, or regional platforms for startup signals and
+    emerging ventures."""
+
+    name = "crowdfunding_platform_spider"

--- a/business_intel_scraper/backend/spiders/cyber_incident_breach_spider.py
+++ b/business_intel_scraper/backend/spiders/cyber_incident_breach_spider.py
@@ -1,0 +1,13 @@
+"""Monitor data breach notification sites, leak forums, or pastebins for company
+mentions."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class CyberIncidentBreachSpider(scrapy.Spider):
+    """Monitor data breach notification sites, leak forums, or pastebins for company
+    mentions."""
+
+    name = "cyber_incident_breach_spider"

--- a/business_intel_scraper/backend/spiders/domain_registration_spider.py
+++ b/business_intel_scraper/backend/spiders/domain_registration_spider.py
@@ -1,0 +1,13 @@
+"""Track newly registered or expired domains linked to target companies (WHOIS,
+DNS data)."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class DomainRegistrationSpider(scrapy.Spider):
+    """Track newly registered or expired domains linked to target companies (WHOIS,
+    DNS data)."""
+
+    name = "domain_registration_spider"

--- a/business_intel_scraper/backend/spiders/employee_review_spider.py
+++ b/business_intel_scraper/backend/spiders/employee_review_spider.py
@@ -1,0 +1,13 @@
+"""Gather reviews/ratings from Glassdoor, Indeed, or regional equivalents for
+culture and sentiment insights."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class EmployeeReviewSpider(scrapy.Spider):
+    """Gather reviews/ratings from Glassdoor, Indeed, or regional equivalents for
+    culture and sentiment insights."""
+
+    name = "employee_review_spider"

--- a/business_intel_scraper/backend/spiders/environmental_violation_spider.py
+++ b/business_intel_scraper/backend/spiders/environmental_violation_spider.py
@@ -1,0 +1,13 @@
+"""Harvest environmental violation or compliance records from EPA, regional, or
+global sources."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class EnvironmentalViolationSpider(scrapy.Spider):
+    """Harvest environmental violation or compliance records from EPA, regional, or
+    global sources."""
+
+    name = "environmental_violation_spider"

--- a/business_intel_scraper/backend/spiders/export_control_list_spider.py
+++ b/business_intel_scraper/backend/spiders/export_control_list_spider.py
@@ -1,0 +1,13 @@
+"""Monitor changes to export control/restricted items lists relevant to target
+sectors."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class ExportControlListSpider(scrapy.Spider):
+    """Monitor changes to export control/restricted items lists relevant to target
+    sectors."""
+
+    name = "export_control_list_spider"

--- a/business_intel_scraper/backend/spiders/facility_plant_location_spider.py
+++ b/business_intel_scraper/backend/spiders/facility_plant_location_spider.py
@@ -1,0 +1,13 @@
+"""Scrape manufacturing plant, warehouse, or R&D location data from multiple
+sources."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class FacilityPlantLocationSpider(scrapy.Spider):
+    """Scrape manufacturing plant, warehouse, or R&D location data from multiple
+    sources."""
+
+    name = "facility_plant_location_spider"

--- a/business_intel_scraper/backend/spiders/financial_filings_spider.py
+++ b/business_intel_scraper/backend/spiders/financial_filings_spider.py
@@ -1,0 +1,11 @@
+"""Collect SEC or similar regulatory filings for detailed financial data."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class FinancialFilingsSpider(scrapy.Spider):
+    """Collect SEC or similar regulatory filings for detailed financial data."""
+
+    name = "financial_filings_spider"

--- a/business_intel_scraper/backend/spiders/financial_news_spider.py
+++ b/business_intel_scraper/backend/spiders/financial_news_spider.py
@@ -1,0 +1,13 @@
+"""Monitor financial news sites or stock exchange announcements for market
+insights."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class FinancialNewsSpider(scrapy.Spider):
+    """Monitor financial news sites or stock exchange announcements for market
+    insights."""
+
+    name = "financial_news_spider"

--- a/business_intel_scraper/backend/spiders/geographic_directory_spider.py
+++ b/business_intel_scraper/backend/spiders/geographic_directory_spider.py
@@ -1,0 +1,13 @@
+"""Scrape online business directories for companies in a particular city or
+region."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class GeographicDirectorySpider(scrapy.Spider):
+    """Scrape online business directories for companies in a particular city or
+    region."""
+
+    name = "geographic_directory_spider"

--- a/business_intel_scraper/backend/spiders/government_contract_portal_spider.py
+++ b/business_intel_scraper/backend/spiders/government_contract_portal_spider.py
@@ -1,0 +1,13 @@
+"""Harvest awarded contracts and procurement notices for defense or government
+spending."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class GovernmentContractPortalSpider(scrapy.Spider):
+    """Harvest awarded contracts and procurement notices for defense or government
+    spending."""
+
+    name = "government_contract_portal_spider"

--- a/business_intel_scraper/backend/spiders/grant_or_funding_database_spider.py
+++ b/business_intel_scraper/backend/spiders/grant_or_funding_database_spider.py
@@ -1,0 +1,13 @@
+"""Collect information on grants or venture capital investments for early-stage
+companies."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class GrantOrFundingDatabaseSpider(scrapy.Spider):
+    """Collect information on grants or venture capital investments for early-stage
+    companies."""
+
+    name = "grant_or_funding_database_spider"

--- a/business_intel_scraper/backend/spiders/import_export_trade_spider.py
+++ b/business_intel_scraper/backend/spiders/import_export_trade_spider.py
@@ -1,0 +1,11 @@
+"""Collect bill of lading, import/export, or customs declaration data."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class ImportExportTradeSpider(scrapy.Spider):
+    """Collect bill of lading, import/export, or customs declaration data."""
+
+    name = "import_export_trade_spider"

--- a/business_intel_scraper/backend/spiders/industry_reports_spider.py
+++ b/business_intel_scraper/backend/spiders/industry_reports_spider.py
@@ -1,0 +1,13 @@
+"""Fetch downloadable reports or whitepapers from industry associations or
+research groups."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class IndustryReportsSpider(scrapy.Spider):
+    """Fetch downloadable reports or whitepapers from industry associations or
+    research groups."""
+
+    name = "industry_reports_spider"

--- a/business_intel_scraper/backend/spiders/job_listings_spider.py
+++ b/business_intel_scraper/backend/spiders/job_listings_spider.py
@@ -1,0 +1,13 @@
+"""Extract open job postings from major employment boards to gauge hiring
+trends."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class JobListingsSpider(scrapy.Spider):
+    """Extract open job postings from major employment boards to gauge hiring
+    trends."""
+
+    name = "job_listings_spider"

--- a/business_intel_scraper/backend/spiders/litigation_and_lawsuit_spider.py
+++ b/business_intel_scraper/backend/spiders/litigation_and_lawsuit_spider.py
@@ -1,0 +1,13 @@
+"""Scrape court dockets or litigation trackers for cases involving target
+companies."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class LitigationLawsuitSpider(scrapy.Spider):
+    """Scrape court dockets or litigation trackers for cases involving target
+    companies."""
+
+    name = "litigation_and_lawsuit_spider"

--- a/business_intel_scraper/backend/spiders/lobbyist_registry_spider.py
+++ b/business_intel_scraper/backend/spiders/lobbyist_registry_spider.py
@@ -1,0 +1,11 @@
+"""Extract records from lobbying registries to map influence networks."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class LobbyistRegistrySpider(scrapy.Spider):
+    """Extract records from lobbying registries to map influence networks."""
+
+    name = "lobbyist_registry_spider"

--- a/business_intel_scraper/backend/spiders/logistics_and_shipping_spider.py
+++ b/business_intel_scraper/backend/spiders/logistics_and_shipping_spider.py
@@ -1,0 +1,13 @@
+"""Scrape maritime, aviation, or ground logistics trackers for import/export,
+shipments, or asset movements."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class LogisticsShippingSpider(scrapy.Spider):
+    """Scrape maritime, aviation, or ground logistics trackers for import/export,
+    shipments, or asset movements."""
+
+    name = "logistics_and_shipping_spider"

--- a/business_intel_scraper/backend/spiders/marketplace_spider.py
+++ b/business_intel_scraper/backend/spiders/marketplace_spider.py
@@ -1,0 +1,13 @@
+"""Harvest seller profiles and product portfolios from Amazon, Alibaba, eBay,
+MercadoLibre, etc."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class MarketplaceSpider(scrapy.Spider):
+    """Harvest seller profiles and product portfolios from Amazon, Alibaba, eBay,
+    MercadoLibre, etc."""
+
+    name = "marketplace_spider"

--- a/business_intel_scraper/backend/spiders/news_article_spider.py
+++ b/business_intel_scraper/backend/spiders/news_article_spider.py
@@ -1,0 +1,13 @@
+"""Scrape targeted news sites for articles mentioning selected businesses or
+keywords."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class NewsArticleSpider(scrapy.Spider):
+    """Scrape targeted news sites for articles mentioning selected businesses or
+    keywords."""
+
+    name = "news_article_spider"

--- a/business_intel_scraper/backend/spiders/open_source_contributions_spider.py
+++ b/business_intel_scraper/backend/spiders/open_source_contributions_spider.py
@@ -1,0 +1,13 @@
+"""Scrape GitHub, GitLab, etc. for company-affiliated OSS activity and project
+contributions."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class OpenSourceContributionsSpider(scrapy.Spider):
+    """Scrape GitHub, GitLab, etc. for company-affiliated OSS activity and project
+    contributions."""
+
+    name = "open_source_contributions_spider"

--- a/business_intel_scraper/backend/spiders/patent_trademark_spider.py
+++ b/business_intel_scraper/backend/spiders/patent_trademark_spider.py
@@ -1,0 +1,13 @@
+"""Gather patent or trademark filings to understand new product or technology
+areas."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class PatentTrademarkSpider(scrapy.Spider):
+    """Gather patent or trademark filings to understand new product or technology
+    areas."""
+
+    name = "patent_trademark_spider"

--- a/business_intel_scraper/backend/spiders/permits_and_licensing_spider.py
+++ b/business_intel_scraper/backend/spiders/permits_and_licensing_spider.py
@@ -1,0 +1,13 @@
+"""Collect business, import/export, or industry-specific licenses from
+government portals."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class PermitsLicensingSpider(scrapy.Spider):
+    """Collect business, import/export, or industry-specific licenses from
+    government portals."""
+
+    name = "permits_and_licensing_spider"

--- a/business_intel_scraper/backend/spiders/procurement_bidding_spider.py
+++ b/business_intel_scraper/backend/spiders/procurement_bidding_spider.py
@@ -1,0 +1,13 @@
+"""Scrape government/commercial procurement tender boards for bid opportunities
+and outcomes."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class ProcurementBiddingSpider(scrapy.Spider):
+    """Scrape government/commercial procurement tender boards for bid opportunities
+    and outcomes."""
+
+    name = "procurement_bidding_spider"

--- a/business_intel_scraper/backend/spiders/product_review_spider.py
+++ b/business_intel_scraper/backend/spiders/product_review_spider.py
@@ -1,0 +1,13 @@
+"""Gather reviews from e-commerce sites to analyze sentiment about specific
+products or brands."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class ProductReviewSpider(scrapy.Spider):
+    """Gather reviews from e-commerce sites to analyze sentiment about specific
+    products or brands."""
+
+    name = "product_review_spider"

--- a/business_intel_scraper/backend/spiders/public_record_spider.py
+++ b/business_intel_scraper/backend/spiders/public_record_spider.py
@@ -1,0 +1,13 @@
+"""Collect publicly available legal records, such as court cases or regulatory
+actions."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class PublicRecordSpider(scrapy.Spider):
+    """Collect publicly available legal records, such as court cases or regulatory
+    actions."""
+
+    name = "public_record_spider"

--- a/business_intel_scraper/backend/spiders/real_estate_listing_spider.py
+++ b/business_intel_scraper/backend/spiders/real_estate_listing_spider.py
@@ -1,0 +1,13 @@
+"""Track commercial real estate listings to understand property holdings or
+expansions."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class RealEstateListingSpider(scrapy.Spider):
+    """Track commercial real estate listings to understand property holdings or
+    expansions."""
+
+    name = "real_estate_listing_spider"

--- a/business_intel_scraper/backend/spiders/sanctions_and_watchlist_spider.py
+++ b/business_intel_scraper/backend/spiders/sanctions_and_watchlist_spider.py
@@ -1,0 +1,13 @@
+"""Scrape international sanctions, blacklists, and watchlists (OFAC, UN, EU,
+etc.) for due diligence."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class SanctionsWatchlistSpider(scrapy.Spider):
+    """Scrape international sanctions, blacklists, and watchlists (OFAC, UN, EU,
+    etc.) for due diligence."""
+
+    name = "sanctions_and_watchlist_spider"

--- a/business_intel_scraper/backend/spiders/security_advisory_spider.py
+++ b/business_intel_scraper/backend/spiders/security_advisory_spider.py
@@ -1,0 +1,13 @@
+"""Monitor vendor security advisories to track incidents or vulnerabilities
+affecting key suppliers."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class SecurityAdvisorySpider(scrapy.Spider):
+    """Monitor vendor security advisories to track incidents or vulnerabilities
+    affecting key suppliers."""
+
+    name = "security_advisory_spider"

--- a/business_intel_scraper/backend/spiders/social_media_profile_spider.py
+++ b/business_intel_scraper/backend/spiders/social_media_profile_spider.py
@@ -1,0 +1,13 @@
+"""Gather public information from company or executive profiles on platforms
+like LinkedIn or Twitter."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class SocialMediaProfileSpider(scrapy.Spider):
+    """Gather public information from company or executive profiles on platforms
+    like LinkedIn or Twitter."""
+
+    name = "social_media_profile_spider"

--- a/business_intel_scraper/backend/spiders/supply_chain_spider.py
+++ b/business_intel_scraper/backend/spiders/supply_chain_spider.py
@@ -1,0 +1,13 @@
+"""Harvest supplier information from logistics or trade databases for supply
+chain mapping."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class SupplyChainSpider(scrapy.Spider):
+    """Harvest supplier information from logistics or trade databases for supply
+    chain mapping."""
+
+    name = "supply_chain_spider"

--- a/business_intel_scraper/backend/spiders/tax_lien_spider.py
+++ b/business_intel_scraper/backend/spiders/tax_lien_spider.py
@@ -1,0 +1,11 @@
+"""Extract tax lien and property tax delinquency data for risk analysis."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class TaxLienSpider(scrapy.Spider):
+    """Extract tax lien and property tax delinquency data for risk analysis."""
+
+    name = "tax_lien_spider"

--- a/business_intel_scraper/backend/spiders/vendor_partner_spider.py
+++ b/business_intel_scraper/backend/spiders/vendor_partner_spider.py
@@ -1,0 +1,11 @@
+"""Gather partnership announcements, vendor lists, or strategic alliance data."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class VendorPartnerSpider(scrapy.Spider):
+    """Gather partnership announcements, vendor lists, or strategic alliance data."""
+
+    name = "vendor_partner_spider"

--- a/business_intel_scraper/backend/spiders/website_technology_stack_spider.py
+++ b/business_intel_scraper/backend/spiders/website_technology_stack_spider.py
@@ -1,0 +1,13 @@
+"""Scrape for usage of web technologies (Wappalyzer, BuiltWith) to assess
+technical sophistication."""
+
+from __future__ import annotations
+
+import scrapy
+
+
+class WebsiteTechnologyStackSpider(scrapy.Spider):
+    """Scrape for usage of web technologies (Wappalyzer, BuiltWith) to assess
+    technical sophistication."""
+
+    name = "website_technology_stack_spider"

--- a/business_intel_scraper/backend/tests/test_spider_modules.py
+++ b/business_intel_scraper/backend/tests/test_spider_modules.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import pytest
+
+spiders = pytest.importorskip("business_intel_scraper.backend.spiders")
+
+
+def test_spider_modules_exist() -> None:
+    for name in spiders.__all__:
+        assert hasattr(spiders, name)


### PR DESCRIPTION
## Summary
- add new placeholder spider modules for future scraping
- include simple test to ensure spider modules import

## Testing
- `ruff check business_intel_scraper/backend/spiders business_intel_scraper/backend/tests/test_spider_modules.py`
- `black business_intel_scraper/backend/spiders business_intel_scraper/backend/tests/test_spider_modules.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_6879893f017483338dd6851332066062