### PR TITLE
Add placeholder spiders for multiple registries

### DIFF
--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/apple_app_store_enterprise_developer_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/apple_app_store_enterprise_developer_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class AppleAppStoreEnterpriseDeveloperSpider(scrapy.Spider):
+    """Placeholder for the Apple App Store Enterprise Developer."""
+
+    name = "apple_app_store_enterprise_developer_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/bangladesh_grameen_bank_borrower_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/bangladesh_grameen_bank_borrower_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class BangladeshGrameenBankBorrowerSpider(scrapy.Spider):
+    """Placeholder for the Bangladesh Grameen Bank Borrower."""
+
+    name = "bangladesh_grameen_bank_borrower_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/cambodia_mfi_borrower_list_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/cambodia_mfi_borrower_list_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class CambodiaMfiBorrowerListSpider(scrapy.Spider):
+    """Placeholder for the Cambodia MFI Borrower List."""
+
+    name = "cambodia_mfi_borrower_list_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/dubai_expo_exhibitor_list_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/dubai_expo_exhibitor_list_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class DubaiExpoExhibitorListSpider(scrapy.Spider):
+    """Placeholder for the Dubai Expo Exhibitor List."""
+
+    name = "dubai_expo_exhibitor_list_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/dubai_land_department_commercial_lease_registry_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/dubai_land_department_commercial_lease_registry_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class DubaiLandDepartmentCommercialLeaseRegistrySpider(scrapy.Spider):
+    """Placeholder for the Dubai Land Department Commercial Lease Registry."""
+
+    name = "dubai_land_department_commercial_lease_registry_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/dubai_silicon_oasis_incubator_list_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/dubai_silicon_oasis_incubator_list_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class DubaiSiliconOasisIncubatorListSpider(scrapy.Spider):
+    """Placeholder for the Dubai Silicon Oasis Incubator List."""
+
+    name = "dubai_silicon_oasis_incubator_list_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/egypt_suez_canal_economic_zone_company_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/egypt_suez_canal_economic_zone_company_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class EgyptSuezCanalEconomicZoneCompanySpider(scrapy.Spider):
+    """Placeholder for the Egypt Suez Canal Economic Zone Company."""
+
+    name = "egypt_suez_canal_economic_zone_company_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/eu_horizon_grant_recipient_company_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/eu_horizon_grant_recipient_company_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class EuHorizonGrantRecipientCompanySpider(scrapy.Spider):
+    """Placeholder for the EU Horizon Grant Recipient Company."""
+
+    name = "eu_horizon_grant_recipient_company_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/eu_joint_transfer_pricing_forum_ruling_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/eu_joint_transfer_pricing_forum_ruling_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class EuJointTransferPricingForumRulingSpider(scrapy.Spider):
+    """Placeholder for the EU Joint Transfer Pricing Forum Ruling."""
+
+    name = "eu_joint_transfer_pricing_forum_ruling_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/eu_rapex_safety_alert_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/eu_rapex_safety_alert_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class EuRapexSafetyAlertSpider(scrapy.Spider):
+    """Placeholder for the EU RAPEX Safety Alert."""
+
+    name = "eu_rapex_safety_alert_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/google_play_publisher_registry_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/google_play_publisher_registry_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class GooglePlayPublisherRegistrySpider(scrapy.Spider):
+    """Placeholder for the Google Play Publisher Registry."""
+
+    name = "google_play_publisher_registry_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/india_gift_city_sez_company_list_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/india_gift_city_sez_company_list_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class IndiaGiftCitySezCompanyListSpider(scrapy.Spider):
+    """Placeholder for the India GIFT City SEZ Company List."""
+
+    name = "india_gift_city_sez_company_list_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/india_mfin_microfinance_registry_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/india_mfin_microfinance_registry_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class IndiaMfinMicrofinanceRegistrySpider(scrapy.Spider):
+    """Placeholder for the India MFIN Microfinance Registry."""
+
+    name = "india_mfin_microfinance_registry_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/indonesia_kaskus_business_complaint_thread_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/indonesia_kaskus_business_complaint_thread_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class IndonesiaKaskusBusinessComplaintThreadSpider(scrapy.Spider):
+    """Placeholder for the Indonesia Kaskus Business Complaint Thread."""
+
+    name = "indonesia_kaskus_business_complaint_thread_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/israel_innovation_authority_grant_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/israel_innovation_authority_grant_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class IsraelInnovationAuthorityGrantSpider(scrapy.Spider):
+    """Placeholder for the Israel Innovation Authority Grant."""
+
+    name = "israel_innovation_authority_grant_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/israel_mod_authorized_vendor_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/israel_mod_authorized_vendor_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class IsraelModAuthorizedVendorSpider(scrapy.Spider):
+    """Placeholder for the Israel MOD Authorized Vendor."""
+
+    name = "israel_mod_authorized_vendor_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/israel_tel_aviv_tech_park_company_list_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/israel_tel_aviv_tech_park_company_list_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class IsraelTelAvivTechParkCompanyListSpider(scrapy.Spider):
+    """Placeholder for the Israel Tel Aviv Tech Park Company List."""
+
+    name = "israel_tel_aviv_tech_park_company_list_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/japan_cabinet_office_bcp_filing_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/japan_cabinet_office_bcp_filing_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class JapanCabinetOfficeBcpFilingSpider(scrapy.Spider):
+    """Placeholder for the Japan Cabinet Office BCP Filing."""
+
+    name = "japan_cabinet_office_bcp_filing_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/kazakhstan_khorgos_sez_licensee_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/kazakhstan_khorgos_sez_licensee_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class KazakhstanKhorgosSezLicenseeSpider(scrapy.Spider):
+    """Placeholder for the Kazakhstan Khorgos SEZ Licensee."""
+
+    name = "kazakhstan_khorgos_sez_licensee_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/malaysia_company_secretary_directory_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/malaysia_company_secretary_directory_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class MalaysiaCompanySecretaryDirectorySpider(scrapy.Spider):
+    """Placeholder for the Malaysia Company Secretary Directory."""
+
+    name = "malaysia_company_secretary_directory_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/malaysia_edge_sme_ranking_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/malaysia_edge_sme_ranking_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class MalaysiaEdgeSmeRankingSpider(scrapy.Spider):
+    """Placeholder for the Malaysia Edge SME Ranking."""
+
+    name = "malaysia_edge_sme_ranking_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/malaysia_exim_bank_guarantee_award_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/malaysia_exim_bank_guarantee_award_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class MalaysiaEximBankGuaranteeAwardSpider(scrapy.Spider):
+    """Placeholder for the Malaysia Exim Bank Guarantee Award."""
+
+    name = "malaysia_exim_bank_guarantee_award_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/malaysia_jpph_property_sale_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/malaysia_jpph_property_sale_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class MalaysiaJpphPropertySaleSpider(scrapy.Spider):
+    """Placeholder for the Malaysia JPPH Property Sale."""
+
+    name = "malaysia_jpph_property_sale_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/malaysia_magic_impact_company_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/malaysia_magic_impact_company_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class MalaysiaMagicImpactCompanySpider(scrapy.Spider):
+    """Placeholder for the Malaysia MaGIC Impact Company."""
+
+    name = "malaysia_magic_impact_company_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/malaysia_mesti_product_recall_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/malaysia_mesti_product_recall_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class MalaysiaMestiProductRecallSpider(scrapy.Spider):
+    """Placeholder for the Malaysia MESTI Product Recall."""
+
+    name = "malaysia_mesti_product_recall_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/malaysia_mosti_r_d_grant_recipient_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/malaysia_mosti_r_d_grant_recipient_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class MalaysiaMostiRDGrantRecipientSpider(scrapy.Spider):
+    """Placeholder for the Malaysia MOSTI R&D Grant Recipient."""
+
+    name = "malaysia_mosti_r_d_grant_recipient_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/malaysia_ssm_banned_director_list_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/malaysia_ssm_banned_director_list_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class MalaysiaSsmBannedDirectorListSpider(scrapy.Spider):
+    """Placeholder for the Malaysia SSM Banned Director List."""
+
+    name = "malaysia_ssm_banned_director_list_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/malaysia_youth_entrepreneur_award_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/malaysia_youth_entrepreneur_award_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class MalaysiaYouthEntrepreneurAwardSpider(scrapy.Spider):
+    """Placeholder for the Malaysia Youth Entrepreneur Award."""
+
+    name = "malaysia_youth_entrepreneur_award_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/mas_scam_alert_list_singapore_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/mas_scam_alert_list_singapore_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class MasScamAlertListSingaporeSpider(scrapy.Spider):
+    """Placeholder for the MAS Scam Alert List  (Singapore)."""
+
+    name = "mas_scam_alert_list_singapore_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_advance_tax_ruling_register_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_advance_tax_ruling_register_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class PolandAdvanceTaxRulingRegisterSpider(scrapy.Spider):
+    """Placeholder for the Poland Advance Tax Ruling Register."""
+
+    name = "poland_advance_tax_ruling_register_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_army_procurement_award_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_army_procurement_award_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class PolandArmyProcurementAwardSpider(scrapy.Spider):
+    """Placeholder for the Poland Army Procurement Award."""
+
+    name = "poland_army_procurement_award_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_cepik_commercial_vehicle_owner_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_cepik_commercial_vehicle_owner_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class PolandCepikCommercialVehicleOwnerSpider(scrapy.Spider):
+    """Placeholder for the Poland CEPIK Commercial Vehicle Owner."""
+
+    name = "poland_cepik_commercial_vehicle_owner_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_crisis_management_plan_registry_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_crisis_management_plan_registry_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class PolandCrisisManagementPlanRegistrySpider(scrapy.Spider):
+    """Placeholder for the Poland Crisis Management Plan Registry."""
+
+    name = "poland_crisis_management_plan_registry_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_economic_forum_exhibitor_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_economic_forum_exhibitor_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class PolandEconomicForumExhibitorSpider(scrapy.Spider):
+    """Placeholder for the Poland Economic Forum Exhibitor."""
+
+    name = "poland_economic_forum_exhibitor_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_gpw_related_party_filing_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_gpw_related_party_filing_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class PolandGpwRelatedPartyFilingSpider(scrapy.Spider):
+    """Placeholder for the Poland GPW Related Party Filing."""
+
+    name = "poland_gpw_related_party_filing_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_gus_real_estate_transaction_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_gus_real_estate_transaction_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class PolandGusRealEstateTransactionSpider(scrapy.Spider):
+    """Placeholder for the Poland GUS Real Estate Transaction."""
+
+    name = "poland_gus_real_estate_transaction_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_knf_scam_list_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_knf_scam_list_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class PolandKnfScamListSpider(scrapy.Spider):
+    """Placeholder for the Poland KNF Scam List."""
+
+    name = "poland_knf_scam_list_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_kuke_export_insurance_award_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_kuke_export_insurance_award_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class PolandKukeExportInsuranceAwardSpider(scrapy.Spider):
+    """Placeholder for the Poland KUKE Export Insurance Award."""
+
+    name = "poland_kuke_export_insurance_award_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_kuke_payout_disclosure_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_kuke_payout_disclosure_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class PolandKukePayoutDisclosureSpider(scrapy.Spider):
+    """Placeholder for the Poland KUKE Payout Disclosure."""
+
+    name = "poland_kuke_payout_disclosure_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_notary_business_agent_registry_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_notary_business_agent_registry_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class PolandNotaryBusinessAgentRegistrySpider(scrapy.Spider):
+    """Placeholder for the Poland Notary Business Agent Registry."""
+
+    name = "poland_notary_business_agent_registry_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_opinie_o_firmach_complaint_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_opinie_o_firmach_complaint_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class PolandOpinieOFirmachComplaintSpider(scrapy.Spider):
+    """Placeholder for the Poland Opinie O Firmach Complaint."""
+
+    name = "poland_opinie_o_firmach_complaint_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_przetargi_online_announcement_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_przetargi_online_announcement_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class PolandPrzetargiOnlineAnnouncementSpider(scrapy.Spider):
+    """Placeholder for the Poland Przetargi Online Announcement."""
+
+    name = "poland_przetargi_online_announcement_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_puls_biznesu_fastest_growing_list_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_puls_biznesu_fastest_growing_list_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class PolandPulsBiznesuFastestGrowingListSpider(scrapy.Spider):
+    """Placeholder for the Poland Puls Biznesu Fastest Growing List."""
+
+    name = "poland_puls_biznesu_fastest_growing_list_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_social_economy_register_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_social_economy_register_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class PolandSocialEconomyRegisterSpider(scrapy.Spider):
+    """Placeholder for the Poland Social Economy Register."""
+
+    name = "poland_social_economy_register_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_youth_startup_competition_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_youth_startup_competition_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class PolandYouthStartupCompetitionSpider(scrapy.Spider):
+    """Placeholder for the Poland Youth Startup Competition."""
+
+    name = "poland_youth_startup_competition_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/russia_goszakupki_tender_award_news_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/russia_goszakupki_tender_award_news_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class RussiaGoszakupkiTenderAwardNewsSpider(scrapy.Spider):
+    """Placeholder for the Russia Goszakupki Tender Award News."""
+
+    name = "russia_goszakupki_tender_award_news_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/russia_otzovik_review_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/russia_otzovik_review_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class RussiaOtzovikReviewSpider(scrapy.Spider):
+    """Placeholder for the Russia Otzovik Review."""
+
+    name = "russia_otzovik_review_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/saudi_tadawul_rpt_disclosure_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/saudi_tadawul_rpt_disclosure_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class SaudiTadawulRptDisclosureSpider(scrapy.Spider):
+    """Placeholder for the Saudi Tadawul RPT Disclosure."""
+
+    name = "saudi_tadawul_rpt_disclosure_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/sgx_20_f_related_party_transaction_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/sgx_20_f_related_party_transaction_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class Sgx20FRelatedPartyTransactionSpider(scrapy.Spider):
+    """Placeholder for the SGX 20-F Related Party Transaction."""
+
+    name = "sgx_20_f_related_party_transaction_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/shopify_app_partner_registry_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/shopify_app_partner_registry_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class ShopifyAppPartnerRegistrySpider(scrapy.Spider):
+    """Placeholder for the Shopify App Partner Registry."""
+
+    name = "shopify_app_partner_registry_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_acra_director_disqualification_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_acra_director_disqualification_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class SingaporeAcraDirectorDisqualificationSpider(scrapy.Spider):
+    """Placeholder for the Singapore ACRA Director Disqualification."""
+
+    name = "singapore_acra_director_disqualification_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_block71_startup_directory_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_block71_startup_directory_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class SingaporeBlock71StartupDirectorySpider(scrapy.Spider):
+    """Placeholder for the Singapore Block71 Startup Directory."""
+
+    name = "singapore_block71_startup_directory_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_ecgc_payout_registry_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_ecgc_payout_registry_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class SingaporeEcgcPayoutRegistrySpider(scrapy.Spider):
+    """Placeholder for the Singapore ECGC Payout Registry."""
+
+    name = "singapore_ecgc_payout_registry_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_ecgc_recipient_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_ecgc_recipient_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class SingaporeEcgcRecipientSpider(scrapy.Spider):
+    """Placeholder for the Singapore ECGC Recipient."""
+
+    name = "singapore_ecgc_recipient_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_enterprisesg_bcp_reporting_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_enterprisesg_bcp_reporting_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class SingaporeEnterprisesgBcpReportingSpider(scrapy.Spider):
+    """Placeholder for the Singapore EnterpriseSG BCP Reporting."""
+
+    name = "singapore_enterprisesg_bcp_reporting_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_fintech_festival_startup_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_fintech_festival_startup_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class SingaporeFintechFestivalStartupSpider(scrapy.Spider):
+    """Placeholder for the Singapore Fintech Festival Startup."""
+
+    name = "singapore_fintech_festival_startup_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_iras_apa_ruling_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_iras_apa_ruling_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class SingaporeIrasApaRulingSpider(scrapy.Spider):
+    """Placeholder for the Singapore IRAS APA Ruling."""
+
+    name = "singapore_iras_apa_ruling_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_lta_fleet_licensee_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_lta_fleet_licensee_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class SingaporeLtaFleetLicenseeSpider(scrapy.Spider):
+    """Placeholder for the Singapore LTA Fleet Licensee."""
+
+    name = "singapore_lta_fleet_licensee_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_mindef_supplier_registry_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_mindef_supplier_registry_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class SingaporeMindefSupplierRegistrySpider(scrapy.Spider):
+    """Placeholder for the Singapore MINDEF Supplier Registry."""
+
+    name = "singapore_mindef_supplier_registry_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_mof_ppp_project_list_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_mof_ppp_project_list_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class SingaporeMofPppProjectListSpider(scrapy.Spider):
+    """Placeholder for the Singapore MOF PPP Project List."""
+
+    name = "singapore_mof_ppp_project_list_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_nrf_research_grant_winner_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_nrf_research_grant_winner_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class SingaporeNrfResearchGrantWinnerSpider(scrapy.Spider):
+    """Placeholder for the Singapore NRF Research Grant Winner."""
+
+    name = "singapore_nrf_research_grant_winner_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_raise_social_enterprise_directory_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_raise_social_enterprise_directory_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class SingaporeRaiseSocialEnterpriseDirectorySpider(scrapy.Spider):
+    """Placeholder for the Singapore raiSE Social Enterprise Directory."""
+
+    name = "singapore_raise_social_enterprise_directory_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_registered_filing_agent_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_registered_filing_agent_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class SingaporeRegisteredFilingAgentSpider(scrapy.Spider):
+    """Placeholder for the Singapore Registered Filing Agent."""
+
+    name = "singapore_registered_filing_agent_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_sfa_food_recall_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_sfa_food_recall_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class SingaporeSfaFoodRecallSpider(scrapy.Spider):
+    """Placeholder for the Singapore SFA Food Recall."""
+
+    name = "singapore_sfa_food_recall_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_sme100_ranking_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_sme100_ranking_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class SingaporeSme100RankingSpider(scrapy.Spider):
+    """Placeholder for the Singapore SME100 Ranking."""
+
+    name = "singapore_sme100_ranking_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_ura_lease_transaction_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_ura_lease_transaction_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class SingaporeUraLeaseTransactionSpider(scrapy.Spider):
+    """Placeholder for the Singapore URA Lease Transaction."""
+
+    name = "singapore_ura_lease_transaction_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/stripe_payment_partner_directory_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/stripe_payment_partner_directory_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class StripePaymentPartnerDirectorySpider(scrapy.Spider):
+    """Placeholder for the Stripe Payment Partner Directory."""
+
+    name = "stripe_payment_partner_directory_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_bddk_suspicious_bank_account_closure_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_bddk_suspicious_bank_account_closure_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class TurkeyBddkSuspiciousBankAccountClosureSpider(scrapy.Spider):
+    """Placeholder for the Turkey BDDK Suspicious Bank Account Closure."""
+
+    name = "turkey_bddk_suspicious_bank_account_closure_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_capital_markets_board_scam_warning_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_capital_markets_board_scam_warning_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class TurkeyCapitalMarketsBoardScamWarningSpider(scrapy.Spider):
+    """Placeholder for the Turkey Capital Markets Board Scam Warning."""
+
+    name = "turkey_capital_markets_board_scam_warning_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_competition_board_director_ban_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_competition_board_director_ban_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class TurkeyCompetitionBoardDirectorBanSpider(scrapy.Spider):
+    """Placeholder for the Turkey Competition Board Director Ban."""
+
+    name = "turkey_competition_board_director_ban_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_eurasia_rail_trade_show_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_eurasia_rail_trade_show_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class TurkeyEurasiaRailTradeShowSpider(scrapy.Spider):
+    """Placeholder for the Turkey Eurasia Rail Trade Show."""
+
+    name = "turkey_eurasia_rail_trade_show_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_it_valley_startup_directory_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_it_valley_startup_directory_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class TurkeyItValleyStartupDirectorySpider(scrapy.Spider):
+    """Placeholder for the Turkey IT Valley Startup Directory."""
+
+    name = "turkey_it_valley_startup_directory_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_ppp_project_award_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_ppp_project_award_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class TurkeyPppProjectAwardSpider(scrapy.Spider):
+    """Placeholder for the Turkey PPP Project Award."""
+
+    name = "turkey_ppp_project_award_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_product_safety_recall_registry_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_product_safety_recall_registry_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class TurkeyProductSafetyRecallRegistrySpider(scrapy.Spider):
+    """Placeholder for the Turkey Product Safety Recall Registry."""
+
+    name = "turkey_product_safety_recall_registry_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_sikayetvar_business_review_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_sikayetvar_business_review_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class TurkeySikayetvarBusinessReviewSpider(scrapy.Spider):
+    """Placeholder for the Turkey Sikayetvar Business Review."""
+
+    name = "turkey_sikayetvar_business_review_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_turk_eximbank_award_list_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_turk_eximbank_award_list_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class TurkeyTurkEximbankAwardListSpider(scrapy.Spider):
+    """Placeholder for the Turkey Turk Eximbank Award List."""
+
+    name = "turkey_turk_eximbank_award_list_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_tuvturk_fleet_registry_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_tuvturk_fleet_registry_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class TurkeyTuvturkFleetRegistrySpider(scrapy.Spider):
+    """Placeholder for the Turkey TUVTURK Fleet Registry."""
+
+    name = "turkey_tuvturk_fleet_registry_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/uae_armed_forces_procurement_list_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/uae_armed_forces_procurement_list_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class UaeArmedForcesProcurementListSpider(scrapy.Spider):
+    """Placeholder for the UAE Armed Forces Procurement List."""
+
+    name = "uae_armed_forces_procurement_list_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/uae_central_bank_suspicious_account_notice_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/uae_central_bank_suspicious_account_notice_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class UaeCentralBankSuspiciousAccountNoticeSpider(scrapy.Spider):
+    """Placeholder for the UAE Central Bank Suspicious Account Notice."""
+
+    name = "uae_central_bank_suspicious_account_notice_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/uae_dmcc_free_zone_licensee_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/uae_dmcc_free_zone_licensee_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class UaeDmccFreeZoneLicenseeSpider(scrapy.Spider):
+    """Placeholder for the UAE DMCC Free Zone Licensee."""
+
+    name = "uae_dmcc_free_zone_licensee_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/uae_forbes_me_top_companies_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/uae_forbes_me_top_companies_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class UaeForbesMeTopCompaniesSpider(scrapy.Spider):
+    """Placeholder for the UAE Forbes ME Top Companies."""
+
+    name = "uae_forbes_me_top_companies_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/uae_ministry_of_finance_ppp_registry_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/uae_ministry_of_finance_ppp_registry_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class UaeMinistryOfFinancePppRegistrySpider(scrapy.Spider):
+    """Placeholder for the UAE Ministry of Finance PPP Registry."""
+
+    name = "uae_ministry_of_finance_ppp_registry_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/uae_sca_fraudulent_scheme_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/uae_sca_fraudulent_scheme_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class UaeScaFraudulentSchemeSpider(scrapy.Spider):
+    """Placeholder for the UAE SCA Fraudulent Scheme."""
+
+    name = "uae_sca_fraudulent_scheme_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/uae_social_impact_entity_registry_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/uae_social_impact_entity_registry_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class UaeSocialImpactEntityRegistrySpider(scrapy.Spider):
+    """Placeholder for the UAE Social Impact Entity Registry."""
+
+    name = "uae_social_impact_entity_registry_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/uae_young_business_talent_winner_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/uae_young_business_talent_winner_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class UaeYoungBusinessTalentWinnerSpider(scrapy.Spider):
+    """Placeholder for the UAE Young Business Talent Winner."""
+
+    name = "uae_young_business_talent_winner_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/uk_hm_treasury_ppp_project_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/uk_hm_treasury_ppp_project_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class UkHmTreasuryPppProjectSpider(scrapy.Spider):
+    """Placeholder for the UK HM Treasury PPP Project."""
+
+    name = "uk_hm_treasury_ppp_project_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/uk_insolvency_service_disqualified_director_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/uk_insolvency_service_disqualified_director_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class UkInsolvencyServiceDisqualifiedDirectorSpider(scrapy.Spider):
+    """Placeholder for the UK Insolvency Service Disqualified Director."""
+
+    name = "uk_insolvency_service_disqualified_director_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/us_ex_im_bank_award_payout_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/us_ex_im_bank_award_payout_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class UsExImBankAwardPayoutSpider(scrapy.Spider):
+    """Placeholder for the US Ex-Im Bank Award Payout."""
+
+    name = "us_ex_im_bank_award_payout_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/us_fda_product_recall_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/us_fda_product_recall_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class UsFdaProductRecallSpider(scrapy.Spider):
+    """Placeholder for the US FDA Product Recall."""
+
+    name = "us_fda_product_recall_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/us_occ_public_enforcement_action_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/us_occ_public_enforcement_action_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class UsOccPublicEnforcementActionSpider(scrapy.Spider):
+    """Placeholder for the US OCC Public Enforcement Action."""
+
+    name = "us_occ_public_enforcement_action_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/vietnam_dau_thau_contract_release_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/vietnam_dau_thau_contract_release_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class VietnamDauThauContractReleaseSpider(scrapy.Spider):
+    """Placeholder for the Vietnam Dau Thau Contract Release."""
+
+    name = "vietnam_dau_thau_contract_release_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/warsaw_google_campus_resident_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/warsaw_google_campus_resident_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class WarsawGoogleCampusResidentSpider(scrapy.Spider):
+    """Placeholder for the Warsaw Google Campus Resident."""
+
+    name = "warsaw_google_campus_resident_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/weibo_china_business_complaint_spider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/weibo_china_business_complaint_spider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scrapy
+
+
+class WeiboChinaBusinessComplaintSpider(scrapy.Spider):
+    """Placeholder for the Weibo China Business Complaint."""
+
+    name = "weibo_china_business_complaint_spider"
+
+    def parse(self, response: scrapy.http.Response):
+        raise NotImplementedError("Spider not yet implemented")


### PR DESCRIPTION
## Summary
- add numerous placeholder spider modules under `crawler_project/spiders`
- each stub defines a Scrapy spider class raising `NotImplementedError`

## Testing
- `ruff check business_intel_scraper/backend/crawlers/crawler_project/spiders`
- `black business_intel_scraper/backend/crawlers/crawler_project/spiders/*.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'settings')*

------
https://chatgpt.com/codex/tasks/task_e_68798d93e9bc8333a16180884339355a