### PR TITLE
Add placeholder spider modules

### DIFF
--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/amazon_brand_registry_violation.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/amazon_brand_registry_violation.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class AmazonBrandRegistryViolationSpider(scrapy.Spider):
+    name = "amazon_brand_registry_violation"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/dubai_airports_commercial_partner.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/dubai_airports_commercial_partner.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class DubaiAirportsCommercialPartnerSpider(scrapy.Spider):
+    name = "dubai_airports_commercial_partner"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/ebay_vero_violation_list.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/ebay_vero_violation_list.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class EbayVeroViolationListSpider(scrapy.Spider):
+    name = "ebay_vero_violation_list"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/egypt_state_asset_sale_announcement.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/egypt_state_asset_sale_announcement.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class EgyptStateAssetSaleAnnouncementSpider(scrapy.Spider):
+    name = "egypt_state_asset_sale_announcement"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/eu_anti_counterfeiting_group_warning.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/eu_anti_counterfeiting_group_warning.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class EuAntiCounterfeitingGroupWarningSpider(scrapy.Spider):
+    name = "eu_anti_counterfeiting_group_warning"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/japan_fsa_crypto_exchange_registry.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/japan_fsa_crypto_exchange_registry.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class JapanFsaCryptoExchangeRegistrySpider(scrapy.Spider):
+    name = "japan_fsa_crypto_exchange_registry"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/kazakhstan_samruk_kazyna_privatization_tender.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/kazakhstan_samruk_kazyna_privatization_tender.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class KazakhstanSamrukKazynaPrivatizationTenderSpider(scrapy.Spider):
+    name = "kazakhstan_samruk_kazyna_privatization_tender"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/kazakhstan_samruk_kazyna_soe_sale.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/kazakhstan_samruk_kazyna_soe_sale.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class KazakhstanSamrukKazynaSoeSaleSpider(scrapy.Spider):
+    name = "kazakhstan_samruk_kazyna_soe_sale"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/lazada_counterfeit_dispute.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/lazada_counterfeit_dispute.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class LazadaCounterfeitDisputeSpider(scrapy.Spider):
+    name = "lazada_counterfeit_dispute"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/malaysia_bursa_esos_disclosure.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/malaysia_bursa_esos_disclosure.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class MalaysiaBursaEsosDisclosureSpider(scrapy.Spider):
+    name = "malaysia_bursa_esos_disclosure"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/malaysia_tourism_malaysia_licensed_agent.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/malaysia_tourism_malaysia_licensed_agent.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class MalaysiaTourismMalaysiaLicensedAgentSpider(scrapy.Spider):
+    name = "malaysia_tourism_malaysia_licensed_agent"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/malta_gaming_authority_licensee.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/malta_gaming_authority_licensee.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class MaltaGamingAuthorityLicenseeSpider(scrapy.Spider):
+    name = "malta_gaming_authority_licensee"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/monaco_yacht_registry.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/monaco_yacht_registry.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class MonacoYachtRegistrySpider(scrapy.Spider):
+    name = "monaco_yacht_registry"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_energy_regulatory_office_consumption_data.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_energy_regulatory_office_consumption_data.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class PolandEnergyRegulatoryOfficeConsumptionDataSpider(scrapy.Spider):
+    name = "poland_energy_regulatory_office_consumption_data"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_gis_inspection_registry.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_gis_inspection_registry.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class PolandGisInspectionRegistrySpider(scrapy.Spider):
+    name = "poland_gis_inspection_registry"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_gpw_green_bond_registry.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_gpw_green_bond_registry.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class PolandGpwGreenBondRegistrySpider(scrapy.Spider):
+    name = "poland_gpw_green_bond_registry"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_infoshare_startup_contest_winner.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_infoshare_startup_contest_winner.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class PolandInfoshareStartupContestWinnerSpider(scrapy.Spider):
+    name = "poland_infoshare_startup_contest_winner"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_kdpw_securitization_registry.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_kdpw_securitization_registry.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class PolandKdpwSecuritizationRegistrySpider(scrapy.Spider):
+    name = "poland_kdpw_securitization_registry"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_knf_crypto_exchange_list.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_knf_crypto_exchange_list.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class PolandKnfCryptoExchangeListSpider(scrapy.Spider):
+    name = "poland_knf_crypto_exchange_list"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_knf_payment_agent_register.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_knf_payment_agent_register.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class PolandKnfPaymentAgentRegisterSpider(scrapy.Spider):
+    name = "poland_knf_payment_agent_register"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_local_municipal_market_permit.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_local_municipal_market_permit.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class PolandLocalMunicipalMarketPermitSpider(scrapy.Spider):
+    name = "poland_local_municipal_market_permit"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_lot_polish_airlines_service_provider.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_lot_polish_airlines_service_provider.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class PolandLotPolishAirlinesServiceProviderSpider(scrapy.Spider):
+    name = "poland_lot_polish_airlines_service_provider"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_luxury_real_estate_buyer.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_luxury_real_estate_buyer.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class PolandLuxuryRealEstateBuyerSpider(scrapy.Spider):
+    name = "poland_luxury_real_estate_buyer"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_ministry_of_state_assets_auction.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_ministry_of_state_assets_auction.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class PolandMinistryOfStateAssetsAuctionSpider(scrapy.Spider):
+    name = "poland_ministry_of_state_assets_auction"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_ministry_of_state_assets_privatization_tender.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_ministry_of_state_assets_privatization_tender.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class PolandMinistryOfStateAssetsPrivatizationTenderSpider(scrapy.Spider):
+    name = "poland_ministry_of_state_assets_privatization_tender"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_opinie_google_review_aggregator.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_opinie_google_review_aggregator.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class PolandOpinieGoogleReviewAggregatorSpider(scrapy.Spider):
+    name = "poland_opinie_google_review_aggregator"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_totalizator_sportowy_agent_list.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_totalizator_sportowy_agent_list.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class PolandTotalizatorSportowyAgentListSpider(scrapy.Spider):
+    name = "poland_totalizator_sportowy_agent_list"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_trade_investment_promotion_section_event.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_trade_investment_promotion_section_event.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class PolandTradeInvestmentPromotionSectionEventSpider(scrapy.Spider):
+    name = "poland_trade_investment_promotion_section_event"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_uke_cloud_services_registry.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_uke_cloud_services_registry.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class PolandUkeCloudServicesRegistrySpider(scrapy.Spider):
+    name = "poland_uke_cloud_services_registry"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_ure_consumer_complaint_registry.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/poland_ure_consumer_complaint_registry.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class PolandUreConsumerComplaintRegistrySpider(scrapy.Spider):
+    name = "poland_ure_consumer_complaint_registry"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/rotterdam_port_terminal_operator.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/rotterdam_port_terminal_operator.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class RotterdamPortTerminalOperatorSpider(scrapy.Spider):
+    name = "rotterdam_port_terminal_operator"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/russia_roskomnadzor_blocked_domain_list.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/russia_roskomnadzor_blocked_domain_list.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class RussiaRoskomnadzorBlockedDomainListSpider(scrapy.Spider):
+    name = "russia_roskomnadzor_blocked_domain_list"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_changi_airport_licensee.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_changi_airport_licensee.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class SingaporeChangiAirportLicenseeSpider(scrapy.Spider):
+    name = "singapore_changi_airport_licensee"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_cra_casino_license_registry.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_cra_casino_license_registry.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class SingaporeCraCasinoLicenseRegistrySpider(scrapy.Spider):
+    name = "singapore_cra_casino_license_registry"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_ema_dispute_resolution.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_ema_dispute_resolution.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class SingaporeEmaDisputeResolutionSpider(scrapy.Spider):
+    name = "singapore_ema_dispute_resolution"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_ema_large_user_consumption.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_ema_large_user_consumption.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class SingaporeEmaLargeUserConsumptionSpider(scrapy.Spider):
+    name = "singapore_ema_large_user_consumption"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_enterprisesg_overseas_mission.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_enterprisesg_overseas_mission.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class SingaporeEnterprisesgOverseasMissionSpider(scrapy.Spider):
+    name = "singapore_enterprisesg_overseas_mission"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_gcb_good_class_bungalow_transaction.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_gcb_good_class_bungalow_transaction.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class SingaporeGcbGoodClassBungalowTransactionSpider(scrapy.Spider):
+    name = "singapore_gcb_good_class_bungalow_transaction"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_imda_data_center_licensee.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_imda_data_center_licensee.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class SingaporeImdaDataCenterLicenseeSpider(scrapy.Spider):
+    name = "singapore_imda_data_center_licensee"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_imda_influencer_disclosure_registry.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_imda_influencer_disclosure_registry.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class SingaporeImdaInfluencerDisclosureRegistrySpider(scrapy.Spider):
+    name = "singapore_imda_influencer_disclosure_registry"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_imda_innovation_award_winner.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_imda_innovation_award_winner.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class SingaporeImdaInnovationAwardWinnerSpider(scrapy.Spider):
+    name = "singapore_imda_innovation_award_winner"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_imda_website_block_list.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_imda_website_block_list.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class SingaporeImdaWebsiteBlockListSpider(scrapy.Spider):
+    name = "singapore_imda_website_block_list"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_ipos_gray_market_watch.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_ipos_gray_market_watch.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class SingaporeIposGrayMarketWatchSpider(scrapy.Spider):
+    name = "singapore_ipos_gray_market_watch"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_mas_crypto_exchange_licensee.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_mas_crypto_exchange_licensee.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class SingaporeMasCryptoExchangeLicenseeSpider(scrapy.Spider):
+    name = "singapore_mas_crypto_exchange_licensee"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_mas_e_money_licensee.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_mas_e_money_licensee.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class SingaporeMasEMoneyLicenseeSpider(scrapy.Spider):
+    name = "singapore_mas_e_money_licensee"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_mas_remittance_licensee.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_mas_remittance_licensee.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class SingaporeMasRemittanceLicenseeSpider(scrapy.Spider):
+    name = "singapore_mas_remittance_licensee"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_mas_spv_register.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_mas_spv_register.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class SingaporeMasSpvRegisterSpider(scrapy.Spider):
+    name = "singapore_mas_spv_register"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_nea_hawker_stall_registry.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_nea_hawker_stall_registry.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class SingaporeNeaHawkerStallRegistrySpider(scrapy.Spider):
+    name = "singapore_nea_hawker_stall_registry"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_psa_container_line_owner.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_psa_container_line_owner.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class SingaporePsaContainerLineOwnerSpider(scrapy.Spider):
+    name = "singapore_psa_container_line_owner"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_seedly_business_review.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_seedly_business_review.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class SingaporeSeedlyBusinessReviewSpider(scrapy.Spider):
+    name = "singapore_seedly_business_review"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_sfa_food_safety_offender.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_sfa_food_safety_offender.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class SingaporeSfaFoodSafetyOffenderSpider(scrapy.Spider):
+    name = "singapore_sfa_food_safety_offender"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_sgx_employee_benefit_plan_filing.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_sgx_employee_benefit_plan_filing.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class SingaporeSgxEmployeeBenefitPlanFilingSpider(scrapy.Spider):
+    name = "singapore_sgx_employee_benefit_plan_filing"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_sgx_green_bond_listing.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_sgx_green_bond_listing.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class SingaporeSgxGreenBondListingSpider(scrapy.Spider):
+    name = "singapore_sgx_green_bond_listing"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_stb_registered_tour_operator.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_stb_registered_tour_operator.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class SingaporeStbRegisteredTourOperatorSpider(scrapy.Spider):
+    name = "singapore_stb_registered_tour_operator"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_temasek_asset_restructuring.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/singapore_temasek_asset_restructuring.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class SingaporeTemasekAssetRestructuringSpider(scrapy.Spider):
+    name = "singapore_temasek_asset_restructuring"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_bddk_mobile_payment_licensee.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_bddk_mobile_payment_licensee.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class TurkeyBddkMobilePaymentLicenseeSpider(scrapy.Spider):
+    name = "turkey_bddk_mobile_payment_licensee"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_bddk_payment_institution_registry.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_bddk_payment_institution_registry.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class TurkeyBddkPaymentInstitutionRegistrySpider(scrapy.Spider):
+    name = "turkey_bddk_payment_institution_registry"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_btk_internet_blacklist.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_btk_internet_blacklist.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class TurkeyBtkInternetBlacklistSpider(scrapy.Spider):
+    name = "turkey_btk_internet_blacklist"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_ek_i_s_zl_k_business_review.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_ek_i_s_zl_k_business_review.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class TurkeyEkISZlKBusinessReviewSpider(scrapy.Spider):
+    name = "turkey_ek_i_s_zl_k_business_review"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_emra_utility_complaint_board.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_emra_utility_complaint_board.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class TurkeyEmraUtilityComplaintBoardSpider(scrapy.Spider):
+    name = "turkey_emra_utility_complaint_board"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_energy_market_regulatory_authority_industrial_use.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_energy_market_regulatory_authority_industrial_use.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class TurkeyEnergyMarketRegulatoryAuthorityIndustrialUseSpider(scrapy.Spider):
+    name = "turkey_energy_market_regulatory_authority_industrial_use"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_milli_piyango_licensee.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_milli_piyango_licensee.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class TurkeyMilliPiyangoLicenseeSpider(scrapy.Spider):
+    name = "turkey_milli_piyango_licensee"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_rtuk_influencer_brand_partnership.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_rtuk_influencer_brand_partnership.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class TurkeyRtukInfluencerBrandPartnershipSpider(scrapy.Spider):
+    name = "turkey_rtuk_influencer_brand_partnership"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_startup_istanbul_hackathon_winner.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_startup_istanbul_hackathon_winner.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class TurkeyStartupIstanbulHackathonWinnerSpider(scrapy.Spider):
+    name = "turkey_startup_istanbul_hackathon_winner"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_tursab_licensed_agency.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/turkey_tursab_licensed_agency.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class TurkeyTursabLicensedAgencySpider(scrapy.Spider):
+    name = "turkey_tursab_licensed_agency"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/uae_adgm_spv_company_list.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/uae_adgm_spv_company_list.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class UaeAdgmSpvCompanyListSpider(scrapy.Spider):
+    name = "uae_adgm_spv_company_list"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/uae_adx_sustainable_bond_list.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/uae_adx_sustainable_bond_list.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class UaeAdxSustainableBondListSpider(scrapy.Spider):
+    name = "uae_adx_sustainable_bond_list"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/uae_central_bank_money_transfer_agent.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/uae_central_bank_money_transfer_agent.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class UaeCentralBankMoneyTransferAgentSpider(scrapy.Spider):
+    name = "uae_central_bank_money_transfer_agent"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/uae_dp_world_terminal_operator.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/uae_dp_world_terminal_operator.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class UaeDpWorldTerminalOperatorSpider(scrapy.Spider):
+    name = "uae_dp_world_terminal_operator"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/uae_dubai_land_department_uhnwi_property.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/uae_dubai_land_department_uhnwi_property.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class UaeDubaiLandDepartmentUhnwiPropertySpider(scrapy.Spider):
+    name = "uae_dubai_land_department_uhnwi_property"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/uae_municipality_souq_license_holder.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/uae_municipality_souq_license_holder.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class UaeMunicipalitySouqLicenseHolderSpider(scrapy.Spider):
+    name = "uae_municipality_souq_license_holder"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/uae_national_lottery_agent.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/uae_national_lottery_agent.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class UaeNationalLotteryAgentSpider(scrapy.Spider):
+    name = "uae_national_lottery_agent"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/uae_nmc_social_media_partnership_disclosure.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/uae_nmc_social_media_partnership_disclosure.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class UaeNmcSocialMediaPartnershipDisclosureSpider(scrapy.Spider):
+    name = "uae_nmc_social_media_partnership_disclosure"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/uae_tdra_data_center_operator.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/uae_tdra_data_center_operator.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class UaeTdraDataCenterOperatorSpider(scrapy.Spider):
+    name = "uae_tdra_data_center_operator"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/uk_gambling_commission_licensee.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/uk_gambling_commission_licensee.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class UkGamblingCommissionLicenseeSpider(scrapy.Spider):
+    name = "uk_gambling_commission_licensee"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/us_cbp_gray_market_seizure.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/us_cbp_gray_market_seizure.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class UsCbpGrayMarketSeizureSpider(scrapy.Spider):
+    name = "us_cbp_gray_market_seizure"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/us_city_health_inspection_report.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/us_city_health_inspection_report.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class UsCityHealthInspectionReportSpider(scrapy.Spider):
+    name = "us_city_health_inspection_report"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/us_commercial_service_mission_company_list.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/us_commercial_service_mission_company_list.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class UsCommercialServiceMissionCompanyListSpider(scrapy.Spider):
+    name = "us_commercial_service_mission_company_list"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass

--- a/business_intel_scraper/backend/crawlers/crawler_project/spiders/us_sec_form_11_k_esop_disclosure.py
+++ b/business_intel_scraper/backend/crawlers/crawler_project/spiders/us_sec_form_11_k_esop_disclosure.py
@@ -1,0 +1,10 @@
+import scrapy
+
+
+class UsSecForm11KEsopDisclosureSpider(scrapy.Spider):
+    name = "us_sec_form_11_k_esop_disclosure"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response) -> None:
+        pass


### PR DESCRIPTION
## Summary
- create placeholder spiders for various regulatory datasets

## Testing
- `ruff check business_intel_scraper/backend/crawlers/crawler_project/spiders`
- `black business_intel_scraper/backend/crawlers/crawler_project/spiders`
- `pytest -q` *(fails: ModuleNotFoundError and other import issues)*

------
https://chatgpt.com/codex/tasks/task_e_68798d832d388333bcb24ffad1920733