### PR TITLE
Add placeholder spiders for SEA business directories

### DIFF
--- a/business_intel_scraper/backend/modules/crawlers/crawler_project/settings.py
+++ b/business_intel_scraper/backend/modules/crawlers/crawler_project/settings.py
@@ -48,8 +48,12 @@ DOWNLOAD_DELAY = 1
 # See https://docs.scrapy.org/en/latest/topics/downloader-middleware.html
 DOWNLOADER_MIDDLEWARES = {
     # Custom middlewares for proxy handling and request randomization
-    "business_intel_scraper.backend.modules.crawlers.middleware.RandomUserAgentMiddleware": 400,
-    "business_intel_scraper.backend.modules.crawlers.middleware.RandomDelayMiddleware": 410,
+    (
+        "business_intel_scraper.backend.modules.crawlers.middleware.RandomUserAgentMiddleware"
+    ): 400,
+    (
+        "business_intel_scraper.backend.modules.crawlers.middleware.RandomDelayMiddleware"
+    ): 410,
 }
 
 # Default list of User-Agent strings for RandomUserAgentMiddleware

--- a/business_intel_scraper/backend/modules/spiders/abenson_store_locator_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/abenson_store_locator_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Abenson Store Locator."""
+
+import scrapy
+
+
+class AbensonStoreLocatorSpider(scrapy.Spider):
+    name = "abenson_store_locator"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/acra_filing_agent_directory_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/acra_filing_agent_directory_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for ACRA Filing Agent Directory."""
+
+import scrapy
+
+
+class AcraFilingAgentDirectorySpider(scrapy.Spider):
+    name = "acra_filing_agent_directory"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/agfunder_sea_startup_directory_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/agfunder_sea_startup_directory_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for AgFunder SEA Startup Directory."""
+
+import scrapy
+
+
+class AgfunderSeaStartupDirectorySpider(scrapy.Spider):
+    name = "agfunder_sea_startup_directory"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/airbnb_malaysia_listings_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/airbnb_malaysia_listings_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Airbnb Malaysia Listings."""
+
+import scrapy
+
+
+class AirbnbMalaysiaListingsSpider(scrapy.Spider):
+    name = "airbnb_malaysia_listings"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/amata_industrial_park_tenants_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/amata_industrial_park_tenants_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Amata Industrial Park Tenants."""
+
+import scrapy
+
+
+class AmataIndustrialParkTenantsSpider(scrapy.Spider):
+    name = "amata_industrial_park_tenants"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/asiaworks_talent_agency_directory_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/asiaworks_talent_agency_directory_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for AsiaWorks Talent Agency Directory."""
+
+import scrapy
+
+
+class AsiaworksTalentAgencyDirectorySpider(scrapy.Spider):
+    name = "asiaworks_talent_agency_directory"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/asme_digital_agency_directory_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/asme_digital_agency_directory_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for ASME Digital Agency Directory."""
+
+import scrapy
+
+
+class AsmeDigitalAgencyDirectorySpider(scrapy.Spider):
+    name = "asme_digital_agency_directory"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/bank_negara_malaysia_e_money_operators_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/bank_negara_malaysia_e_money_operators_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Bank Negara Malaysia E-money Operators."""
+
+import scrapy
+
+
+class BankNegaraMalaysiaEMoneyOperatorsSpider(scrapy.Spider):
+    name = "bank_negara_malaysia_e_money_operators"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/bank_negara_malaysia_insurance_agents_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/bank_negara_malaysia_insurance_agents_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Bank Negara Malaysia Insurance Agents."""
+
+import scrapy
+
+
+class BankNegaraMalaysiaInsuranceAgentsSpider(scrapy.Spider):
+    name = "bank_negara_malaysia_insurance_agents"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/bca_licensed_builders_developers_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/bca_licensed_builders_developers_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for BCA Licensed Builders and Developers."""
+
+import scrapy
+
+
+class BcaLicensedBuildersDevelopersSpider(scrapy.Spider):
+    name = "bca_licensed_builders_developers"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/bnsp_certified_training_providers_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/bnsp_certified_training_providers_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for BNSP Certified Training Providers."""
+
+import scrapy
+
+
+class BnspCertifiedTrainingProvidersSpider(scrapy.Spider):
+    name = "bnsp_certified_training_providers"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/bsp_microfinance_ngos_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/bsp_microfinance_ngos_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for BSP List of Microfinance NGOs."""
+
+import scrapy
+
+
+class BspMicrofinanceNgosSpider(scrapy.Spider):
+    name = "bsp_microfinance_ngos"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/bureau_of_customs_accredited_brokers_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/bureau_of_customs_accredited_brokers_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Bureau of Customs Accredited Brokers."""
+
+import scrapy
+
+
+class BureauOfCustomsAccreditedBrokersSpider(scrapy.Spider):
+    name = "bureau_of_customs_accredited_brokers"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/cidb_registered_contractors_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/cidb_registered_contractors_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for CIDB Registered Contractors."""
+
+import scrapy
+
+
+class CidbRegisteredContractorsSpider(scrapy.Spider):
+    name = "cidb_registered_contractors"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/cooperative_development_authority_list_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/cooperative_development_authority_list_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Cooperative Development Authority List."""
+
+import scrapy
+
+
+class CooperativeDevelopmentAuthorityListSpider(scrapy.Spider):
+    name = "cooperative_development_authority_list"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/credit_bureau_singapore_members_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/credit_bureau_singapore_members_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Credit Bureau Singapore Members."""
+
+import scrapy
+
+
+class CreditBureauSingaporeMembersSpider(scrapy.Spider):
+    name = "credit_bureau_singapore_members"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/csa_cybersecurity_service_provider_directory_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/csa_cybersecurity_service_provider_directory_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for CSA Cybersecurity Service Provider Directory."""
+
+import scrapy
+
+
+class CsaCybersecurityServiceProviderDirectorySpider(scrapy.Spider):
+    name = "csa_cybersecurity_service_provider_directory"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/csa_service_provider_directory_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/csa_service_provider_directory_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for CSA Singapore Service Provider Directory."""
+
+import scrapy
+
+
+class CsaServiceProviderDirectorySpider(scrapy.Spider):
+    name = "csa_service_provider_directory"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/department_of_fisheries_malaysia_licensed_aquaculture_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/department_of_fisheries_malaysia_licensed_aquaculture_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Department of Fisheries Malaysia Licensed Aquaculture."""
+
+import scrapy
+
+
+class DepartmentOfFisheriesMalaysiaLicensedAquacultureSpider(scrapy.Spider):
+    name = "department_of_fisheries_malaysia_licensed_aquaculture"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/doe_electrification_projects_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/doe_electrification_projects_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for DOE Electrification Projects."""
+
+import scrapy
+
+
+class DoeElectrificationProjectsSpider(scrapy.Spider):
+    name = "doe_electrification_projects"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/doh_accredited_laboratories_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/doh_accredited_laboratories_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for DOH Accredited Laboratories."""
+
+import scrapy
+
+
+class DohAccreditedLaboratoriesSpider(scrapy.Spider):
+    name = "doh_accredited_laboratories"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/e27_edtech_startup_list_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/e27_edtech_startup_list_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for e27 Edtech Startup List."""
+
+import scrapy
+
+
+class E27EdtechStartupListSpider(scrapy.Spider):
+    name = "e27_edtech_startup_list"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/e27_healthtech_startup_list_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/e27_healthtech_startup_list_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for e27 Healthtech Startup List."""
+
+import scrapy
+
+
+class E27HealthtechStartupListSpider(scrapy.Spider):
+    name = "e27_healthtech_startup_list"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/ema_licensed_electrical_contractors_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/ema_licensed_electrical_contractors_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for EMA Licensed Electrical Contractors."""
+
+import scrapy
+
+
+class EmaLicensedElectricalContractorsSpider(scrapy.Spider):
+    name = "ema_licensed_electrical_contractors"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/enterprise_singapore_grants_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/enterprise_singapore_grants_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Enterprise Singapore Grants."""
+
+import scrapy
+
+
+class EnterpriseSingaporeGrantsSpider(scrapy.Spider):
+    name = "enterprise_singapore_grants"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/enterprise_singapore_sme_directory_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/enterprise_singapore_sme_directory_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Enterprise Singapore SME Directory."""
+
+import scrapy
+
+
+class EnterpriseSingaporeSmeDirectorySpider(scrapy.Spider):
+    name = "enterprise_singapore_sme_directory"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/fire_protection_association_malaysia_members_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/fire_protection_association_malaysia_members_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Fire Protection Association Malaysia Members."""
+
+import scrapy
+
+
+class FireProtectionAssociationMalaysiaMembersSpider(scrapy.Spider):
+    name = "fire_protection_association_malaysia_members"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/fmm_members_food_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/fmm_members_food_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for FMM Members (Food)."""
+
+import scrapy
+
+
+class FmmMembersFoodSpider(scrapy.Spider):
+    name = "fmm_members_food"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/hdb_registered_renovation_contractors_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/hdb_registered_renovation_contractors_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for HDB Registered Renovation Contractors."""
+
+import scrapy
+
+
+class HdbRegisteredRenovationContractorsSpider(scrapy.Spider):
+    name = "hdb_registered_renovation_contractors"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/idpro_members_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/idpro_members_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for IDPRO Members (Data Center Association)."""
+
+import scrapy
+
+
+class IdproMembersSpider(scrapy.Spider):
+    name = "idpro_members"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/indonesia_ispo_certified_smallholders_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/indonesia_ispo_certified_smallholders_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Indonesia ISPO Certified Smallholders."""
+
+import scrapy
+
+
+class IndonesiaIspoCertifiedSmallholdersSpider(scrapy.Spider):
+    name = "indonesia_ispo_certified_smallholders"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/indonesia_mining_licensees_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/indonesia_mining_licensees_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Ministry of Energy and Mineral Resources Mining Licensees."""
+
+import scrapy
+
+
+class IndonesiaMiningLicenseesSpider(scrapy.Spider):
+    name = "indonesia_mining_licensees"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/law_society_singapore_member_directory_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/law_society_singapore_member_directory_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Law Society of Singapore Member Directory."""
+
+import scrapy
+
+
+class LawSocietySingaporeMemberDirectorySpider(scrapy.Spider):
+    name = "law_society_singapore_member_directory"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/magic_social_enterprise_directory_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/magic_social_enterprise_directory_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for MaGIC Social Enterprise Directory."""
+
+import scrapy
+
+
+class MagicSocialEnterpriseDirectorySpider(scrapy.Spider):
+    name = "magic_social_enterprise_directory"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/malaysia_f_and_b_directory_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/malaysia_f_and_b_directory_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Malaysia F&B Directory."""
+
+import scrapy
+
+
+class MalaysiaFAndBDirectorySpider(scrapy.Spider):
+    name = "malaysia_f_and_b_directory"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/malaysian_association_of_convention_exhibition_organisers_suppliers_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/malaysian_association_of_convention_exhibition_organisers_suppliers_spider.py
@@ -1,0 +1,15 @@
+"""Placeholder spider for Malaysian Assoc. of Convention & Exhibition Organisers."""
+
+import scrapy
+
+
+class MalaysianAssociationOfConventionExhibitionOrganisersSuppliersSpider(
+    scrapy.Spider
+):
+    name = "malaysian_association_of_convention_exhibition_organisers_suppliers"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/malaysian_dental_council_registered_dentists_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/malaysian_dental_council_registered_dentists_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Malaysian Dental Council Registered Dentists."""
+
+import scrapy
+
+
+class MalaysianDentalCouncilRegisteredDentistsSpider(scrapy.Spider):
+    name = "malaysian_dental_council_registered_dentists"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/malaysian_furniture_council_directory_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/malaysian_furniture_council_directory_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Malaysian Furniture Council Directory."""
+
+import scrapy
+
+
+class MalaysianFurnitureCouncilDirectorySpider(scrapy.Spider):
+    name = "malaysian_furniture_council_directory"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/malaysian_institute_of_accountants_member_directory_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/malaysian_institute_of_accountants_member_directory_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Malaysian Institute of Accountants Member Directory."""
+
+import scrapy
+
+
+class MalaysianInstituteOfAccountantsMemberDirectorySpider(scrapy.Spider):
+    name = "malaysian_institute_of_accountants_member_directory"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/mas_digital_bank_licensees_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/mas_digital_bank_licensees_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for MAS Digital Bank Licensees."""
+
+import scrapy
+
+
+class MasDigitalBankLicenseesSpider(scrapy.Spider):
+    name = "mas_digital_bank_licensees"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/mas_registered_crowdfunding_platforms_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/mas_registered_crowdfunding_platforms_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for MAS Registered Crowdfunding Platforms."""
+
+import scrapy
+
+
+class MasRegisteredCrowdfundingPlatformsSpider(scrapy.Spider):
+    name = "mas_registered_crowdfunding_platforms"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/mcmc_licensed_service_providers_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/mcmc_licensed_service_providers_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for MCMC Licensed Service Providers."""
+
+import scrapy
+
+
+class McmcLicensedServiceProvidersSpider(scrapy.Spider):
+    name = "mcmc_licensed_service_providers"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/ministry_of_finance_eperolehan_supplier_list_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/ministry_of_finance_eperolehan_supplier_list_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Ministry of Finance ePerolehan Supplier List."""
+
+import scrapy
+
+
+class MinistryOfFinanceEperolehanSupplierListSpider(scrapy.Spider):
+    name = "ministry_of_finance_eperolehan_supplier_list"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/moe_private_education_institutions_directory_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/moe_private_education_institutions_directory_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for MOE Private Education Institutions Directory."""
+
+import scrapy
+
+
+class MoePrivateEducationInstitutionsDirectorySpider(scrapy.Spider):
+    name = "moe_private_education_institutions_directory"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/moe_registered_tuition_centres_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/moe_registered_tuition_centres_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for MOE Registered Tuition Centres."""
+
+import scrapy
+
+
+class MoeRegisteredTuitionCentresSpider(scrapy.Spider):
+    name = "moe_registered_tuition_centres"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/nea_hawkers_directory_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/nea_hawkers_directory_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for NEA Hawkers Directory."""
+
+import scrapy
+
+
+class NeaHawkersDirectorySpider(scrapy.Spider):
+    name = "nea_hawkers_directory"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/nea_waste_management_operator_directory_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/nea_waste_management_operator_directory_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for NEA Waste Management Operator Directory."""
+
+import scrapy
+
+
+class NeaWasteManagementOperatorDirectorySpider(scrapy.Spider):
+    name = "nea_waste_management_operator_directory"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/ojk_licensed_banks_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/ojk_licensed_banks_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for OJK Licensed Banks."""
+
+import scrapy
+
+
+class OjkLicensedBanksSpider(scrapy.Spider):
+    name = "ojk_licensed_banks"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/pelindo_port_services_directory_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/pelindo_port_services_directory_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Pelindo Port Services Directory."""
+
+import scrapy
+
+
+class PelindoPortServicesDirectorySpider(scrapy.Spider):
+    name = "pelindo_port_services_directory"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/pertamina_vendor_directory_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/pertamina_vendor_directory_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Pertamina Vendor Directory."""
+
+import scrapy
+
+
+class PertaminaVendorDirectorySpider(scrapy.Spider):
+    name = "pertamina_vendor_directory"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/philippines_bureau_immigration_accredited_agents_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/philippines_bureau_immigration_accredited_agents_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Philippines Bureau of Immigration Accredited Agents."""
+
+import scrapy
+
+
+class PhilippinesBureauImmigrationAccreditedAgentsSpider(scrapy.Spider):
+    name = "philippines_bureau_immigration_accredited_agents"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/ppp_center_projects_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/ppp_center_projects_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for PPP Center Projects."""
+
+import scrapy
+
+
+class PppCenterProjectsSpider(scrapy.Spider):
+    name = "ppp_center_projects"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/print_media_association_singapore_members_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/print_media_association_singapore_members_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Print & Media Association Singapore Members."""
+
+import scrapy
+
+
+class PrintMediaAssociationSingaporeMembersSpider(scrapy.Spider):
+    name = "print_media_association_singapore_members"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/ptt_franchisee_list_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/ptt_franchisee_list_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for PTT Franchisee List."""
+
+import scrapy
+
+
+class PttFranchiseeListSpider(scrapy.Spider):
+    name = "ptt_franchisee_list"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/public_relations_society_philippines_member_directory_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/public_relations_society_philippines_member_directory_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for PR Society of the Philippines Member Directory."""
+
+import scrapy
+
+
+class PublicRelationsSocietyPhilippinesMemberDirectorySpider(scrapy.Spider):
+    name = "public_relations_society_philippines_member_directory"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/saigon_hi_tech_park_tenants_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/saigon_hi_tech_park_tenants_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Saigon Hi-Tech Park Tenants."""
+
+import scrapy
+
+
+class SaigonHiTechParkTenantsSpider(scrapy.Spider):
+    name = "saigon_hi_tech_park_tenants"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/sbv_authorized_remittance_agents_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/sbv_authorized_remittance_agents_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for SBV Authorized Remittance Agents."""
+
+import scrapy
+
+
+class SbvAuthorizedRemittanceAgentsSpider(scrapy.Spider):
+    name = "sbv_authorized_remittance_agents"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/sec_thailand_p2p_platforms_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/sec_thailand_p2p_platforms_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for SEC Thailand P2P Platforms."""
+
+import scrapy
+
+
+class SecThailandP2pPlatformsSpider(scrapy.Spider):
+    name = "sec_thailand_p2p_platforms"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/seda_malaysia_feed_in_approval_holders_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/seda_malaysia_feed_in_approval_holders_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for SEDA Malaysia Registered Feed-in Approval Holders."""
+
+import scrapy
+
+
+class SedaMalaysiaFeedInApprovalHoldersSpider(scrapy.Spider):
+    name = "seda_malaysia_feed_in_approval_holders"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/seipi_member_companies_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/seipi_member_companies_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for SEIPI Member Companies."""
+
+import scrapy
+
+
+class SeipiMemberCompaniesSpider(scrapy.Spider):
+    name = "seipi_member_companies"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/selangor_logistics_directory_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/selangor_logistics_directory_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Selangor State Investment Centre Logistics Directory."""
+
+import scrapy
+
+
+class SelangorLogisticsDirectorySpider(scrapy.Spider):
+    name = "selangor_logistics_directory"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/sgtech_member_directory_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/sgtech_member_directory_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for SGTech Member Directory."""
+
+import scrapy
+
+
+class SgtechMemberDirectorySpider(scrapy.Spider):
+    name = "sgtech_member_directory"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/shopee_seller_centre_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/shopee_seller_centre_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Shopee Seller Centre."""
+
+import scrapy
+
+
+class ShopeeSellerCentreSpider(scrapy.Spider):
+    name = "shopee_seller_centre"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/singapore_clinic_directory_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/singapore_clinic_directory_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Singapore Clinic Directory."""
+
+import scrapy
+
+
+class SingaporeClinicDirectorySpider(scrapy.Spider):
+    name = "singapore_clinic_directory"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/singapore_green_labelling_scheme_certified_companies_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/singapore_green_labelling_scheme_certified_companies_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Singapore Green Labelling Scheme Certified Companies."""
+
+import scrapy
+
+
+class SingaporeGreenLabellingSchemeCertifiedCompaniesSpider(scrapy.Spider):
+    name = "singapore_green_labelling_scheme_certified_companies"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/singapore_logistics_association_members_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/singapore_logistics_association_members_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Singapore Logistics Association Member Directory."""
+
+import scrapy
+
+
+class SingaporeLogisticsAssociationMembersSpider(scrapy.Spider):
+    name = "singapore_logistics_association_members"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/singapore_pasar_directory_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/singapore_pasar_directory_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Singapore Pasar Directory."""
+
+import scrapy
+
+
+class SingaporePasarDirectorySpider(scrapy.Spider):
+    name = "singapore_pasar_directory"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/singapore_police_force_security_agency_directory_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/singapore_police_force_security_agency_directory_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Singapore Police Force Security Agency Directory."""
+
+import scrapy
+
+
+class SingaporePoliceForceSecurityAgencyDirectorySpider(scrapy.Spider):
+    name = "singapore_police_force_security_agency_directory"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/singapore_restaurant_directory_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/singapore_restaurant_directory_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Singapore Restaurant Directory."""
+
+import scrapy
+
+
+class SingaporeRestaurantDirectorySpider(scrapy.Spider):
+    name = "singapore_restaurant_directory"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/thai_hotels_association_members_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/thai_hotels_association_members_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Thai Hotels Association Members."""
+
+import scrapy
+
+
+class ThaiHotelsAssociationMembersSpider(scrapy.Spider):
+    name = "thai_hotels_association_members"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/thai_plastic_industries_association_members_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/thai_plastic_industries_association_members_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Thai Plastic Industries Association Members."""
+
+import scrapy
+
+
+class ThaiPlasticIndustriesAssociationMembersSpider(scrapy.Spider):
+    name = "thai_plastic_industries_association_members"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/thai_security_association_members_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/thai_security_association_members_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Thai Security Association Members."""
+
+import scrapy
+
+
+class ThaiSecurityAssociationMembersSpider(scrapy.Spider):
+    name = "thai_security_association_members"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/thailand_board_of_investment_manufacturing_companies_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/thailand_board_of_investment_manufacturing_companies_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Thailand Board of Investment - Manufacturing Companies."""
+
+import scrapy
+
+
+class ThailandBoardOfInvestmentManufacturingCompaniesSpider(scrapy.Spider):
+    name = "thailand_board_of_investment_manufacturing_companies"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/thailand_franchise_directory_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/thailand_franchise_directory_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Thailand Franchise Directory."""
+
+import scrapy
+
+
+class ThailandFranchiseDirectorySpider(scrapy.Spider):
+    name = "thailand_franchise_directory"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/vietcombank_sme_lending_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/vietcombank_sme_lending_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Vietcombank SME Lending."""
+
+import scrapy
+
+
+class VietcombankSmeLendingSpider(scrapy.Spider):
+    name = "vietcombank_sme_lending"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/vietnam_association_of_realtors_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/vietnam_association_of_realtors_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Vietnam Association of Realtors."""
+
+import scrapy
+
+
+class VietnamAssociationOfRealtorsSpider(scrapy.Spider):
+    name = "vietnam_association_of_realtors"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/vietnam_fertilizer_association_members_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/vietnam_fertilizer_association_members_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Vietnam Fertilizer Association Members."""
+
+import scrapy
+
+
+class VietnamFertilizerAssociationMembersSpider(scrapy.Spider):
+    name = "vietnam_fertilizer_association_members"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/vietnam_logistics_business_association_members_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/vietnam_logistics_business_association_members_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Vietnam Logistics Business Association Members."""
+
+import scrapy
+
+
+class VietnamLogisticsBusinessAssociationMembersSpider(scrapy.Spider):
+    name = "vietnam_logistics_business_association_members"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/vietnam_pharmacy_chain_list_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/vietnam_pharmacy_chain_list_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Vietnam Pharmacy Chain List (Ministry of Health)."""
+
+import scrapy
+
+
+class VietnamPharmacyChainListSpider(scrapy.Spider):
+    name = "vietnam_pharmacy_chain_list"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/vietnam_renewable_energy_business_directory_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/vietnam_renewable_energy_business_directory_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Vietnam Renewable Energy Business Directory."""
+
+import scrapy
+
+
+class VietnamRenewableEnergyBusinessDirectorySpider(scrapy.Spider):
+    name = "vietnam_renewable_energy_business_directory"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/vietnam_textile_and_apparel_association_members_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/vietnam_textile_and_apparel_association_members_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Vietnam Textile and Apparel Association Members."""
+
+import scrapy
+
+
+class VietnamTextileAndApparelAssociationMembersSpider(scrapy.Spider):
+    name = "vietnam_textile_and_apparel_association_members"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass

--- a/business_intel_scraper/backend/modules/spiders/vietnam_tour_operators_spider.py
+++ b/business_intel_scraper/backend/modules/spiders/vietnam_tour_operators_spider.py
@@ -1,0 +1,13 @@
+"""Placeholder spider for Vietnam National Administration of Tourism Tour Operators."""
+
+import scrapy
+
+
+class VietnamTourOperatorsSpider(scrapy.Spider):
+    name = "vietnam_tour_operators"
+    allowed_domains: list[str] = []
+    start_urls: list[str] = []
+
+    def parse(self, response: scrapy.http.Response):
+        """Parse the response."""
+        pass


### PR DESCRIPTION
## Summary
- add placeholder spider modules for new data sources across Southeast Asia
- shorten long docstrings for some new spiders
- wrap long middleware paths to satisfy linting

## Testing
- `ruff check .`
- `pytest -q` *(fails: test_register_and_login, test_verify_token_rejects_invalid, test_queue_functions, test_fetch_with_playwright_uses_proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687a35d958b0833398bc127a7598ebc9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added initial placeholders for a wide range of directory and listing spiders covering various business, regulatory, and association sources across Southeast Asia.
* **Style**
  * Minor formatting update to middleware settings (no user-facing impact).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->