### PR TITLE
Add wrappers for optional external scrapers

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,15 @@ docker compose up --build
 ```
 See `docs/deployment.md` for Kubernetes deployment instructions.
 
+## Third-Party Integrations
+
+Lightweight wrappers for several external scraping projects are available in
+`business_intel_scraper.backend.integrations`. They expose helper functions for
+running tools like `crawl4ai`, `SecretScraper`, `colly`, `proxy_pool`,
+`spiderfoot` and ProjectDiscovery's `katana`. Each wrapper simply invokes the
+underlying CLI when present and raises ``NotImplementedError`` if the tool is
+missing.
+
 ## Roadmap and Incomplete Features
 
 The repository contains working examples for scraping, simple NLP and OSINT tasks, but several pieces are intentionally stubbed out or incomplete:

--- a/business_intel_scraper/backend/integrations/__init__.py
+++ b/business_intel_scraper/backend/integrations/__init__.py
@@ -1,0 +1,17 @@
+"""Wrappers for optional third-party scraping tools."""
+
+from .crawl4ai_wrapper import run_crawl4ai
+from .secret_scraper_wrapper import run_secret_scraper
+from .colly_wrapper import run_colly
+from .proxy_pool_wrapper import run_proxy_pool
+from .spiderfoot_wrapper import run_spiderfoot
+from .katana_wrapper import run_katana
+
+__all__ = [
+    "run_crawl4ai",
+    "run_secret_scraper",
+    "run_colly",
+    "run_proxy_pool",
+    "run_spiderfoot",
+    "run_katana",
+]

--- a/business_intel_scraper/backend/integrations/colly_wrapper.py
+++ b/business_intel_scraper/backend/integrations/colly_wrapper.py
@@ -1,0 +1,19 @@
+"""Wrapper for the Go-based `colly` scraper."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from subprocess import CompletedProcess
+
+
+def run_colly(*args: str) -> CompletedProcess[str]:
+    """Run the ``colly`` binary if installed."""
+    if shutil.which("colly") is None:
+        raise NotImplementedError("colly binary is not installed")
+    return subprocess.run(
+        ["colly", *args],
+        check=True,
+        text=True,
+        capture_output=True,
+    )

--- a/business_intel_scraper/backend/integrations/crawl4ai_wrapper.py
+++ b/business_intel_scraper/backend/integrations/crawl4ai_wrapper.py
@@ -1,0 +1,22 @@
+"""Minimal wrapper for the external `crawl4ai` crawler."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from subprocess import CompletedProcess
+
+
+def run_crawl4ai(*args: str) -> CompletedProcess[str]:
+    """Run the ``crawl4ai`` CLI with ``args``.
+
+    Raises ``NotImplementedError`` if the binary is missing.
+    """
+    if shutil.which("crawl4ai") is None:
+        raise NotImplementedError("crawl4ai is not installed")
+    return subprocess.run(
+        ["crawl4ai", *args],
+        check=True,
+        text=True,
+        capture_output=True,
+    )

--- a/business_intel_scraper/backend/integrations/katana_wrapper.py
+++ b/business_intel_scraper/backend/integrations/katana_wrapper.py
@@ -1,0 +1,19 @@
+"""Wrapper for ProjectDiscovery's katana crawler."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from subprocess import CompletedProcess
+
+
+def run_katana(*args: str) -> CompletedProcess[str]:
+    """Run the ``katana`` CLI if installed."""
+    if shutil.which("katana") is None:
+        raise NotImplementedError("katana binary is not installed")
+    return subprocess.run(
+        ["katana", *args],
+        check=True,
+        text=True,
+        capture_output=True,
+    )

--- a/business_intel_scraper/backend/integrations/proxy_pool_wrapper.py
+++ b/business_intel_scraper/backend/integrations/proxy_pool_wrapper.py
@@ -1,0 +1,19 @@
+"""Utilities for interacting with the `proxy_pool` project."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from subprocess import CompletedProcess
+
+
+def run_proxy_pool(*args: str) -> CompletedProcess[str]:
+    """Run the proxy_pool ``proxyPool.py`` if installed."""
+    if shutil.which("proxyPool.py") is None:
+        raise NotImplementedError("proxy_pool is not installed")
+    return subprocess.run(
+        ["proxyPool.py", *args],
+        check=True,
+        text=True,
+        capture_output=True,
+    )

--- a/business_intel_scraper/backend/integrations/secret_scraper_wrapper.py
+++ b/business_intel_scraper/backend/integrations/secret_scraper_wrapper.py
@@ -1,0 +1,30 @@
+"""Wrapper for the optional `secretscraper` package."""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+import subprocess
+from subprocess import CompletedProcess
+
+
+def run_secret_scraper(target: str) -> CompletedProcess[str]:
+    """Run SecretScraper against ``target`` if available."""
+    if (
+        importlib.util.find_spec("secretscraper") is None
+        and shutil.which("secretscraper") is None
+    ):
+        raise NotImplementedError("SecretScraper is not installed")
+    if shutil.which("secretscraper"):
+        return subprocess.run(
+            ["secretscraper", target],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+    return subprocess.run(
+        ["python", "-m", "secretscraper", target],
+        check=True,
+        text=True,
+        capture_output=True,
+    )

--- a/business_intel_scraper/backend/integrations/spiderfoot_wrapper.py
+++ b/business_intel_scraper/backend/integrations/spiderfoot_wrapper.py
@@ -1,0 +1,19 @@
+"""Wrapper for the SpiderFoot OSINT framework."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from subprocess import CompletedProcess
+
+
+def run_spiderfoot(*args: str) -> CompletedProcess[str]:
+    """Run SpiderFoot's ``sf.py`` CLI if installed."""
+    if shutil.which("sf.py") is None:
+        raise NotImplementedError("SpiderFoot is not installed")
+    return subprocess.run(
+        ["sf.py", *args],
+        check=True,
+        text=True,
+        capture_output=True,
+    )

--- a/business_intel_scraper/backend/tests/test_integration_wrappers.py
+++ b/business_intel_scraper/backend/tests/test_integration_wrappers.py
@@ -1,0 +1,40 @@
+"""Tests for third-party integration wrappers."""
+
+# ruff: noqa: E402
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+sys.path.insert(0, BASE_DIR)  # noqa: E402
+
+import pytest
+
+from business_intel_scraper.backend.integrations import (
+    run_crawl4ai,
+    run_secret_scraper,
+    run_colly,
+    run_proxy_pool,
+    run_spiderfoot,
+    run_katana,
+)
+
+
+@pytest.mark.parametrize(
+    "func",
+    [
+        run_crawl4ai,
+        run_secret_scraper,
+        run_colly,
+        run_proxy_pool,
+        run_spiderfoot,
+        run_katana,
+    ],
+)
+def test_missing_tools_raise(func: types.FunctionType) -> None:
+    """Ensure wrappers error when tools are not installed."""
+    with pytest.raises(NotImplementedError):
+        func("--help")


### PR DESCRIPTION
## Summary
- integrate thin wrappers around external tools (crawl4ai, SecretScraper, colly, proxy_pool, spiderfoot and katana)
- expose these wrappers via a new `integrations` package
- document the integrations in the README
- add unit tests covering the wrappers

## Testing
- `ruff check business_intel_scraper/backend/integrations business_intel_scraper/backend/tests/test_integration_wrappers.py --fix`
- `black business_intel_scraper/backend/integrations business_intel_scraper/backend/tests/test_integration_wrappers.py`
- `pytest business_intel_scraper/backend/tests/test_integration_wrappers.py -q`
- `pytest -q` *(fails: 5 failed, 73 passed, 5 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_687a3560f92c8333bd846e9c19c8ecf9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added wrappers to enable integration with several third-party scraping tools, allowing invocation of external tools if installed.
* **Documentation**
  * Updated the README with a new section describing available third-party integrations.
* **Tests**
  * Introduced tests to ensure proper error handling when external tools are not installed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->