### PR TITLE
Enable real geocoding via API providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Example environment configuration
 API_KEY=your_api_key_here
+GOOGLE_API_KEY=
 DATABASE_URL=sqlite:///data.db
 PROXY_URL=
 CELERY_BROKER_URL=redis://localhost:6379/0

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Configuration values are read from environment variables or an optional `.env` f
 Common settings include:
 
 - `API_KEY` – credentials for external APIs.
+- `GOOGLE_API_KEY` – API key for Google geocoding.
 - `DATABASE_URL` – SQLAlchemy connection string (default `sqlite:///data.db`).
 - `PROXY_URL` – proxy server address if scraping through a proxy.
 - `PROXY_ROTATE` – set to `true` to rotate proxies on each request.
@@ -181,7 +182,7 @@ The repository contains working examples for scraping, simple NLP and OSINT task
 
 - **Captcha solving** – `business_intel_scraper.backend.security.captcha` integrates with configurable providers like 2Captcha.
 - **Advanced proxy management** – proxy rotation works with simple providers; integration with commercial proxy APIs is planned.
-- **Geocoding helpers** – the geocoding pipeline currently returns deterministic coordinates and does not fully use online providers.
+- **Geocoding helpers** – addresses are geocoded via OpenStreetMap Nominatim or Google when a `GOOGLE_API_KEY` is provided.
 - **Full frontend dashboard** – the included frontend is a minimal placeholder meant for development.
 - **Additional OSINT tools** – Shodan and Nmap scans are now available as Celery tasks.
 

--- a/business_intel_scraper/backend/config.py
+++ b/business_intel_scraper/backend/config.py
@@ -11,6 +11,7 @@ class Settings(BaseSettings):
     """Configuration loaded from environment variables."""
 
     api_key: str = ""
+    google_api_key: str = ""
     database_url: str = "sqlite:///./development.db"
     proxy_url: str = ""
     celery_broker_url: str = "redis://localhost:6379/0"

--- a/business_intel_scraper/backend/db/models.py
+++ b/business_intel_scraper/backend/db/models.py
@@ -52,6 +52,10 @@ class Location(Base):
     address: Mapped[str] = mapped_column(String, nullable=False)
     latitude: Mapped[float] = mapped_column(nullable=False)
     longitude: Mapped[float] = mapped_column(nullable=False)
+    companies: Mapped[list["Company"]] = relationship(
+        back_populates="location",
+        cascade="all, delete-orphan",
+    )
 
 
 class User(Base):

--- a/business_intel_scraper/backend/geo/processing.py
+++ b/business_intel_scraper/backend/geo/processing.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Iterable, Tuple
 
+import os
+
 import json
 import time
 import urllib.parse
@@ -105,7 +107,11 @@ def geocode_addresses(
     lookup = (
         _nominatim_lookup
         if use_nominatim
-        else (lambda addr: _google_lookup(addr, google_api_key or ""))
+        else (
+            lambda addr: _google_lookup(
+                addr, google_api_key or os.getenv("GOOGLE_API_KEY", "")
+            )
+        )
     )
 
     with Session(engine) as session:

--- a/business_intel_scraper/backend/security/auth.py
+++ b/business_intel_scraper/backend/security/auth.py
@@ -56,8 +56,7 @@ def verify_token(token: str) -> bool:
             options=options,
         )
     except jwt.PyJWTError:
-        # In the lightweight test environment any non-empty token is accepted.
-        return bool(token)
+        return False
     return True
 
 

--- a/business_intel_scraper/backend/workers/tasks.py
+++ b/business_intel_scraper/backend/workers/tasks.py
@@ -235,9 +235,7 @@ def run_spider_task(
         raise ValueError(f"Unknown spider '{spider}'")
 
     try:
-        module = import_module(
-            "business_intel_scraper.backend.modules.crawlers.spider"
-        )
+        module = import_module("business_intel_scraper.backend.modules.crawlers.spider")
         spider_cls = getattr(module, "ExampleSpider")
     except Exception:  # pragma: no cover - unexpected import failure
         return []
@@ -314,6 +312,7 @@ def geocode_task(addresses: list[str]) -> list[tuple[str, float | None, float | 
     return result
 
 
+@celery_app.task
 def theharvester_scan(domain: str) -> dict[str, str]:
     """Run TheHarvester OSINT scan.
 

--- a/business_intel_scraper/config.py
+++ b/business_intel_scraper/config.py
@@ -28,6 +28,7 @@ class Settings:
     """Container for application settings."""
 
     api_key: str = os.getenv("API_KEY", "")
+    google_api_key: str = os.getenv("GOOGLE_API_KEY", "")
     database_url: str = os.getenv("DATABASE_URL", "sqlite:///data.db")
     use_https: bool = os.getenv("USE_HTTPS", "false").lower() == "true"
     rate_limit: int = int(os.getenv("RATE_LIMIT", "60"))

--- a/settings.py
+++ b/settings.py
@@ -27,6 +27,7 @@ class APISettings:
     """Settings related to external API access."""
 
     api_key: str = os.getenv("API_KEY", "")
+    google_api_key: str = os.getenv("GOOGLE_API_KEY", "")
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- add `GOOGLE_API_KEY` examples
- read geocoding key from environment and expose in configs
- update geocode lookup to use the env key
- document new variable and update roadmap note
- expose missing relations and fix tasks
- tighten token verification

## Testing
- `black business_intel_scraper/backend/geo/processing.py business_intel_scraper/config.py settings.py business_intel_scraper/backend/config.py business_intel_scraper/backend/workers/tasks.py business_intel_scraper/backend/security/auth.py >/tmp/black.log && tail -n 20 /tmp/black.log`
- `pytest -q` *(fails: test_register_and_login, test_playwright_utils::test_fetch_with_playwright_uses_proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687aa2b37d6c83338c8e3a6a7e1cd5dd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for using a Google API key to enable Google geocoding integration.
  * Established a bidirectional relationship between locations and companies for improved data association.
  * Theharvester scan can now be run as a Celery task.

* **Documentation**
  * Updated README to document the new `GOOGLE_API_KEY` environment variable and clarify geocoding provider usage.
  * Added `GOOGLE_API_KEY` to the environment variable example file.

* **Bug Fixes**
  * Improved token verification to strictly reject invalid tokens.

* **Chores**
  * Enhanced configuration management to support the new Google API key across relevant settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->