### PR TITLE
Add introductory spider tutorial

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,7 @@
 This directory contains supplementary documentation for the Business Intelligence Scraper.
 
 * [Setup](setup.md) – install dependencies and run the stack
+* [Tutorial](tutorial.md) – walk through running a spider
 * [API Usage](api_usage.md) – example requests for the backend
 * [Developer Guide](developer_guide.md) – coding standards and local development
 * [Security](security.md) – JWT configuration and best practices

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,0 +1,87 @@
+# Tutorial: Running Your First Spider
+
+This walkthrough demonstrates how to set up the stack, launch the sample spider, and inspect the results.
+
+## 1. Install prerequisites
+
+- Python 3.11+
+- Node.js (optional, for the demo frontend)
+- Docker and Docker Compose
+
+Clone the repository and create a virtual environment:
+
+```bash
+git clone <repo-url>
+cd scraper
+python -m venv .venv
+source .venv/bin/activate
+```
+
+Install dependencies and copy the example environment file:
+
+```bash
+pip install -r requirements.txt
+cp .env.example .env
+```
+
+Install the frontend dependencies if you want to try the UI:
+
+```bash
+cd business_intel_scraper/frontend
+npm install
+cd ../../
+```
+
+## 2. Start the stack with Docker
+
+A `docker-compose.yml` in `business_intel_scraper/` starts the API and a Celery worker. Launch Redis and bring up the services:
+
+```bash
+docker run -d -p 6379:6379 --name redis redis:7
+cd business_intel_scraper
+docker compose up --build
+```
+
+The API will be available at [http://localhost:8000](http://localhost:8000).
+
+## 3. Launch the example spider
+
+Send a request to the `/scrape` endpoint to start the built-in `ExampleSpider`:
+
+```bash
+curl -X POST http://localhost:8000/scrape
+```
+
+The response contains a `task_id` that can be used to monitor progress:
+
+```bash
+curl http://localhost:8000/tasks/<task_id>
+```
+
+You can also use the provided command line helper which defaults to the local API:
+
+```bash
+python -m business_intel_scraper.cli scrape
+```
+
+## 4. Examine the results
+
+Once the task finishes, fetch the scraped items from the `/data` endpoint:
+
+```bash
+curl http://localhost:8000/data
+```
+
+With the CLI:
+
+```bash
+python -m business_intel_scraper.cli download -o results.json
+```
+
+Logs stream in real time from `/logs/stream` and can be viewed in the browser or with `curl`:
+
+```bash
+curl http://localhost:8000/logs/stream
+```
+
+That's it—you've run a spider and collected its output. Explore the other spiders in `business_intel_scraper/backend/modules/crawlers/spider.py` to expand your scraping jobs.


### PR DESCRIPTION
## Summary
- document how to bring up the stack and run a spider
- link the new tutorial from the docs index

## Testing
- `ruff check .`
- `pytest -q` *(fails: 26 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_687aab802b708333b81b85e25a883bda

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "Tutorial" entry to the documentation, providing a step-by-step guide for running your first spider, including setup instructions, launching and monitoring scraping tasks, and retrieving results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->