### PR TITLE
Add search and limit support to GraphQL

### DIFF
--- a/business_intel_scraper/backend/api/graphql.py
+++ b/business_intel_scraper/backend/api/graphql.py
@@ -20,10 +20,22 @@ class Query:
     """GraphQL queries for scraped data and jobs."""
 
     @strawberry.field
-    def scraped_data(self) -> list[JSON]:
-        """Return all scraped items."""
+    def scraped_data(
+        self, search: str | None = None, limit: int | None = None
+    ) -> list[JSON]:
+        """Return scraped items, optionally filtered by a search term."""
 
-        return api.scraped_data
+        data = api.scraped_data
+        if search:
+            lowered = search.lower()
+            data = [
+                item
+                for item in data
+                if any(lowered in str(value).lower() for value in item.values())
+            ]
+        if limit is not None:
+            data = data[:limit]
+        return data
 
     @strawberry.field
     def job(self, id: ID) -> Job | None:

--- a/business_intel_scraper/backend/tests/test_graphql.py
+++ b/business_intel_scraper/backend/tests/test_graphql.py
@@ -21,3 +21,20 @@ def test_query_scraped_data() -> None:
     resp = client.post("/graphql", json={"query": "{ scrapedData }"})
     assert resp.status_code == 200
     assert resp.json()["data"]["scrapedData"] == []
+
+
+def test_query_scraped_data_search() -> None:
+    api.scraped_data.clear()
+    api.scraped_data.extend(
+        [
+            {"title": "Alpha"},
+            {"title": "Beta"},
+        ]
+    )
+    client = TestClient(app)
+    resp = client.post(
+        "/graphql",
+        json={"query": '{ scrapedData(search: "Beta") }'},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["data"]["scrapedData"] == [{"title": "Beta"}]

--- a/docs/api_usage.md
+++ b/docs/api_usage.md
@@ -56,6 +56,16 @@ curl -X POST \
   http://localhost:8000/graphql
 ```
 
+You can optionally filter results using the `search` argument or limit the
+number returned:
+
+```bash
+curl -X POST \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "{ scrapedData(search: \"foo\", limit: 10) }"}' \
+  http://localhost:8000/graphql
+```
+
 ## Real-Time Notifications
 
 Open a WebSocket connection to `/ws/notifications` to receive broadcast


### PR DESCRIPTION
## Summary
- extend `scraped_data` GraphQL query with `search` and `limit` arguments
- document the optional GraphQL search query
- add tests for new GraphQL filtering

## Testing
- `pytest -q` *(fails: test_metrics_endpoint_exposes_prometheus, test_job_endpoints, test_fetch_with_playwright_uses_proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687aab8039348333a256001ede7c9b27