### PR TITLE
Add architecture and workflow docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,12 @@
 This project provides a modular framework for scraping and analyzing business intelligence data.
 
 ## Overview
+
 The Business Intelligence Scraper is an experimental platform for collecting business data from the web and open-source intelligence (OSINT) tools. It combines Scrapy-based spiders, optional browser automation, and a FastAPI backend with Celery workers for asynchronous jobs.
+
+## Architecture
+
+The repository is organised as a single package named `business_intel_scraper`.  A FastAPI API coordinates scraping tasks executed by Celery workers.  Proxy rotation, NLP helpers and OSINT integrations live in dedicated modules.  Data can be persisted via SQLAlchemy models and Alembic migrations.  A small React dashboard and infrastructure scripts (Docker Compose and Kubernetes) are provided for local and production deployments.  See [docs/architecture.md](docs/architecture.md) for a detailed breakdown.
 
 ## API
 
@@ -158,6 +163,17 @@ curl -X POST http://localhost:8000/scrape # launch the example spider
 ```
 
 Task progress can be queried at `/tasks/<task_id>` and log messages stream from `/logs/stream`.
+
+## Workflow
+
+1. Install dependencies and copy `.env.example` to `.env`.
+2. Start Redis, then run the API and a Celery worker.
+3. Queue jobs via `POST /scrape` or the CLI.
+4. Check `/tasks/<id>` and `/logs/stream` to monitor progress.
+5. Download results from `/export` or via the CLI once jobs complete.
+6. Optional: run Celery beat to execute periodic jobs.
+
+See [docs/workflow.md](docs/workflow.md) for a more detailed walk-through.
 
 ### Command Line Client
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,4 +8,6 @@ This directory contains supplementary documentation for the Business Intelligenc
 * [Security](security.md) – JWT configuration and best practices
 * [Deployment Guide](deployment.md) – deploy with Docker Compose or Kubernetes
 * [Logging](logging.md) – forward logs and aggregate them with ELK
+* [Architecture](architecture.md) – component breakdown and data flow
+* [Workflow](workflow.md) – example development and execution steps
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,69 @@
+# Architecture
+
+This document outlines the structure of the Business Intelligence Scraper project and how its pieces fit together.
+
+## Overview
+
+The repository is organised as a Python package called `business_intel_scraper`.  A FastAPI service exposes HTTP and GraphQL endpoints while Celery workers execute long running scraping and OSINT tasks.  An optional React frontend provides a small dashboard.  Infrastructure scripts allow the stack to run either via Docker Compose or Kubernetes.
+
+## Components
+
+### API service
+- Location: `business_intel_scraper/backend/api`
+- Provides REST and GraphQL endpoints
+- WebSocket notifications and Server-Sent Events for log streaming
+- Middleware for security headers, rate limiting and Prometheus metrics
+- JWT authentication
+
+### Worker processes
+- Location: `business_intel_scraper/backend/workers`
+- Celery tasks for spiders, OSINT integrations and NLP/geo processing
+- Periodic jobs defined in `celery_app.conf.beat_schedule`
+- Falls back to an in-process executor when Celery is not installed
+
+### Scrapers and OSINT modules
+- Example Scrapy spider under `backend/modules/crawlers`
+- External tools wrapped in `backend/integrations`
+
+### Proxy management
+- Pluggable proxy rotation utilities in `backend/proxy`
+
+### Database layer
+- SQLAlchemy models and Alembic migrations in `backend/db`
+- Helper pipeline to persist scraped items
+
+### NLP and geocoding
+- Text cleaning and entity extraction in `backend/nlp`
+- Address geocoding helpers in `backend/geo`
+
+### CLI and frontend
+- `business_intel_scraper/cli.py` provides basic command line access
+- `frontend/` contains a minimal JavaScript UI
+
+### Infrastructure
+- Docker Compose and Dockerfiles under `infra/docker`
+- Kubernetes manifests in `infra/k8s`
+- Monitoring examples in `infra/monitoring`
+
+### Logging and metrics
+- Logs written to `backend/logs/app.log`
+- Prometheus metrics served by the API at `/metrics`
+
+## Directory layout
+
+```text
+business_intel_scraper/
+├── backend/                 # API, workers and core modules
+├── frontend/                # Optional dashboard
+├── infra/                   # Docker and Kubernetes configuration
+└── docs/                    # Project documentation
+```
+
+## Data flow
+
+1. A request to `/scrape` or the CLI queues a task via Celery.
+2. A worker runs the spider or OSINT tool and stores results.
+3. Progress is exposed through `/tasks/{id}` and broadcast on the WebSocket.
+4. Processed data can be exported or further analysed via the API or CLI.
+
+See the root `README.md` for running instructions and `docs/workflow.md` for a walk-through of the typical developer workflow.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,0 +1,27 @@
+# Workflow
+
+The following steps describe a typical development and execution cycle for the Business Intelligence Scraper.
+
+1. **Install dependencies**
+   - Create a virtual environment and run `pip install -r requirements.txt`.
+   - Copy `.env.example` to `.env` and adjust settings.
+2. **Start services**
+   - Ensure Redis is running.
+   - Launch the API with `uvicorn business_intel_scraper.backend.api.main:app`.
+   - Start a Celery worker with `celery -A business_intel_scraper.backend.workers.tasks.celery_app worker`.
+   - Optional: run Celery beat to execute scheduled jobs.
+3. **Queue a job**
+   - Send `POST /scrape` or use `python -m business_intel_scraper.cli scrape`.
+   - The response contains a task identifier.
+4. **Monitor progress**
+   - Poll `/tasks/<id>` for status updates.
+   - Stream logs from `/logs/stream` or connect to `/ws/notifications` for real‑time events.
+   - Metrics are available at `/metrics`.
+5. **Retrieve results**
+   - Call `/data` or `/export?format=csv` to download scraped items.
+   - The CLI also supports `status` and `download` commands.
+6. **Extend the platform**
+   - Add spiders in `backend/modules/crawlers` and their tasks in `backend/workers/tasks.py`.
+   - Update the database models or pipelines as needed and run Alembic migrations.
+
+For containerised setups start Redis, the API and a worker with `docker compose up` from the `business_intel_scraper` directory.  See `docs/deployment.md` for production deployment notes.


### PR DESCRIPTION
## Summary
- document project architecture
- explain end-to-end workflow for running the stack
- link new guides from docs README
- add Architecture and Workflow sections to main README

## Testing
- `pytest -q` *(fails: 26 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_687aaba7a1008333892ff27adae7728e